### PR TITLE
feat: Tambahkan manajemen webhook dari panel admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.2.0] - 2025-08-10
+
+### Ditambahkan
+- Tombol "Edit" di halaman daftar bot untuk masuk ke halaman manajemen bot.
+- Halaman manajemen bot baru (`admin/edit_bot.php`).
+- Fitur untuk `Set Webhook`, `Check Webhook`, dan `Delete Webhook` dari panel admin untuk setiap bot.
+- Penggunaan AJAX dan modal untuk menampilkan hasil aksi webhook tanpa me-refresh halaman.
+- Metode baru (`setWebhook`, `getWebhookInfo`, `deleteWebhook`) di kelas `TelegramAPI`.
+
 ## [1.1.0] - 2025-08-10
 
 ### Ditambahkan

--- a/admin/bots.php
+++ b/admin/bots.php
@@ -73,6 +73,8 @@ $bots = $pdo->query("SELECT id, name, created_at FROM bots ORDER BY created_at D
         input[type="text"] { width: calc(100% - 22px); padding: 10px; margin-bottom: 10px; border: 1px solid #ccc; border-radius: 4px; }
         button { padding: 10px 15px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; }
         button:hover { background-color: #0056b3; }
+        .btn-edit { display: inline-block; padding: 5px 10px; background-color: #28a745; color: white; text-decoration: none; border-radius: 4px; }
+        .btn-edit:hover { background-color: #218838; }
         .alert { padding: 15px; margin-bottom: 20px; border-radius: 4px; }
         .alert-danger { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
         .alert-success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
@@ -111,12 +113,13 @@ $bots = $pdo->query("SELECT id, name, created_at FROM bots ORDER BY created_at D
                     <th>ID</th>
                     <th>Nama</th>
                     <th>Tanggal Dibuat</th>
+                    <th>Aksi</th>
                 </tr>
             </thead>
             <tbody>
                 <?php if (empty($bots)): ?>
                     <tr>
-                        <td colspan="3">Belum ada bot yang ditambahkan.</td>
+                        <td colspan="4">Belum ada bot yang ditambahkan.</td>
                     </tr>
                 <?php else: ?>
                     <?php foreach ($bots as $bot): ?>
@@ -124,6 +127,9 @@ $bots = $pdo->query("SELECT id, name, created_at FROM bots ORDER BY created_at D
                             <td><?= htmlspecialchars($bot['id']) ?></td>
                             <td><?= htmlspecialchars($bot['name']) ?></td>
                             <td><?= htmlspecialchars($bot['created_at']) ?></td>
+                            <td>
+                                <a href="edit_bot.php?id=<?= htmlspecialchars($bot['id']) ?>" class="btn-edit">Edit</a>
+                            </td>
                         </tr>
                     <?php endforeach; ?>
                 <?php endif; ?>

--- a/admin/edit_bot.php
+++ b/admin/edit_bot.php
@@ -1,0 +1,174 @@
+<?php
+session_start();
+require_once __DIR__ . '/../core/database.php';
+require_once __DIR__ . '/../core/helpers.php';
+
+$pdo = get_db_connection();
+$bot = null;
+$error = null;
+
+// Validasi bot ID dari URL
+if (!isset($_GET['id']) || !filter_var($_GET['id'], FILTER_VALIDATE_INT)) {
+    header("Location: bots.php");
+    exit;
+}
+$bot_id = (int)$_GET['id'];
+
+// Ambil data bot dari database
+$stmt = $pdo->prepare("SELECT id, name, token, created_at FROM bots WHERE id = ?");
+$stmt->execute([$bot_id]);
+$bot = $stmt->fetch();
+
+// Jika bot tidak ditemukan, kembali ke halaman daftar bot
+if (!$bot) {
+    header("Location: bots.php");
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Edit Bot: <?= htmlspecialchars($bot['name']) ?> - Admin Panel</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 40px; background-color: #f4f6f8; color: #333; }
+        .container { max-width: 800px; margin: 0 auto; background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        h1, h2 { color: #333; }
+        nav { margin-bottom: 20px; }
+        nav a { text-decoration: none; color: #007bff; padding: 10px; }
+        nav a.active { font-weight: bold; }
+        .bot-info { margin-bottom: 20px; }
+        .bot-info p { margin: 5px 0; }
+        .actions button {
+            padding: 10px 15px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            color: white;
+            margin-right: 10px;
+        }
+        .actions .set-webhook { background-color: #007bff; }
+        .actions .set-webhook:hover { background-color: #0056b3; }
+        .actions .check-webhook { background-color: #17a2b8; }
+        .actions .check-webhook:hover { background-color: #117a8b; }
+        .actions .delete-webhook { background-color: #dc3545; }
+        .actions .delete-webhook:hover { background-color: #c82333; }
+
+        /* Modal Styles */
+        .modal { display: none; position: fixed; z-index: 1; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4); }
+        .modal-content { background-color: #fefefe; margin: 15% auto; padding: 20px; border: 1px solid #888; width: 80%; max-width: 600px; border-radius: 8px; }
+        .close { color: #aaa; float: right; font-size: 28px; font-weight: bold; }
+        .close:hover, .close:focus { color: black; text-decoration: none; cursor: pointer; }
+        #modal-body { white-space: pre-wrap; background-color: #eee; padding: 15px; border-radius: 5px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <nav>
+            <a href="index.php">Percakapan</a> |
+            <a href="bots.php" class="active">Kelola Bot</a>
+        </nav>
+
+        <h1>Edit Bot: <?= htmlspecialchars($bot['name']) ?></h1>
+
+        <div class="bot-info">
+            <h2>Informasi Bot</h2>
+            <p><strong>ID:</strong> <?= htmlspecialchars($bot['id']) ?></p>
+            <p><strong>Nama:</strong> <?= htmlspecialchars($bot['name']) ?></p>
+            <p><strong>Token:</strong> <code><?= substr(htmlspecialchars($bot['token']), 0, 15) ?>...</code></p>
+            <p><strong>Dibuat pada:</strong> <?= htmlspecialchars($bot['created_at']) ?></p>
+        </div>
+
+        <div class="actions">
+            <h2>Manajemen Webhook</h2>
+            <button class="set-webhook" data-bot-id="<?= $bot['id'] ?>">Set Webhook</button>
+            <button class="check-webhook" data-bot-id="<?= $bot['id'] ?>">Check Webhook</button>
+            <button class="delete-webhook" data-bot-id="<?= $bot['id'] ?>">Delete Webhook</button>
+        </div>
+
+    </div>
+
+    <!-- The Modal -->
+    <div id="responseModal" class="modal">
+        <div class="modal-content">
+            <span class="close">&times;</span>
+            <h2 id="modal-title">Hasil Aksi</h2>
+            <pre id="modal-body">Memproses...</pre>
+        </div>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const modal = document.getElementById('responseModal');
+            const modalTitle = document.getElementById('modal-title');
+            const modalBody = document.getElementById('modal-body');
+            const span = document.getElementsByClassName('close')[0];
+
+            // Fungsi untuk menampilkan modal
+            function showModal(title, content) {
+                modalTitle.textContent = title;
+                modalBody.textContent = content;
+                modal.style.display = 'block';
+            }
+
+            // Fungsi untuk menutup modal
+            span.onclick = function() {
+                modal.style.display = 'none';
+            }
+            window.onclick = function(event) {
+                if (event.target == modal) {
+                    modal.style.display = 'none';
+                }
+            }
+
+            // Fungsi untuk menangani aksi webhook
+            async function handleWebhookAction(action, botId) {
+                let confirmation = true;
+                if (action === 'delete') {
+                    confirmation = confirm('Apakah Anda yakin ingin menghapus webhook untuk bot ini?');
+                }
+
+                if (!confirmation) {
+                    return;
+                }
+
+                showModal('Hasil ' + action, 'Sedang memproses permintaan...');
+
+                try {
+                    const response = await fetch('webhook_manager.php', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/x-www-form-urlencoded',
+                        },
+                        body: `action=${action}&bot_id=${botId}`
+                    });
+
+                    if (!response.ok) {
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
+
+                    const result = await response.json();
+                    const formattedResult = JSON.stringify(result.data, null, 2);
+                    showModal('Hasil ' + action, formattedResult);
+
+                } catch (error) {
+                    showModal('Error', 'Gagal melakukan permintaan: ' + error.message);
+                }
+            }
+
+            document.querySelector('.set-webhook').addEventListener('click', function() {
+                handleWebhookAction('set', this.dataset.botId);
+            });
+
+            document.querySelector('.check-webhook').addEventListener('click', function() {
+                handleWebhookAction('check', this.dataset.botId);
+            });
+
+            document.querySelector('.delete-webhook').addEventListener('click', function() {
+                handleWebhookAction('delete', this.dataset.botId);
+            });
+        });
+    </script>
+</body>
+</html>

--- a/admin/webhook_manager.php
+++ b/admin/webhook_manager.php
@@ -1,0 +1,77 @@
+<?php
+header('Content-Type: application/json');
+session_start();
+
+require_once __DIR__ . '/../core/database.php';
+require_once __DIR__ . '/../core/TelegramAPI.php';
+
+// Fungsi untuk mengirim respons JSON dan keluar
+function json_response($status, $data = null) {
+    echo json_encode(['status' => $status, 'data' => $data]);
+    exit;
+}
+
+// 1. Validasi Input
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_POST['action']) || !isset($_POST['bot_id'])) {
+    json_response('error', 'Permintaan tidak valid.');
+}
+
+$action = $_POST['action'];
+$bot_id = filter_var($_POST['bot_id'], FILTER_VALIDATE_INT);
+
+if (!$bot_id) {
+    json_response('error', 'ID Bot tidak valid.');
+}
+
+// 2. Dapatkan Token Bot dari Database
+$pdo = get_db_connection();
+if (!$pdo) {
+    json_response('error', 'Koneksi database gagal.');
+}
+
+$stmt = $pdo->prepare("SELECT token FROM bots WHERE id = ?");
+$stmt->execute([$bot_id]);
+$bot = $stmt->fetch();
+
+if (!$bot) {
+    json_response('error', "Bot dengan ID {$bot_id} tidak ditemukan.");
+}
+$bot_token = $bot['token'];
+
+// 3. Inisialisasi Telegram API
+$telegram = new TelegramAPI($bot_token);
+$result = null;
+
+// 4. Lakukan Aksi Berdasarkan 'action'
+try {
+    switch ($action) {
+        case 'set':
+            // Buat URL webhook secara dinamis
+            $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
+            $domain = $_SERVER['HTTP_HOST'];
+            $webhook_url = $protocol . $domain . dirname($_SERVER['PHP_SELF']) . '/../webhook.php?bot_id=' . $bot_id;
+
+            $result = $telegram->setWebhook($webhook_url);
+            break;
+
+        case 'check':
+            $result = $telegram->getWebhookInfo();
+            break;
+
+        case 'delete':
+            $result = $telegram->deleteWebhook();
+            break;
+
+        default:
+            json_response('error', 'Aksi tidak dikenal.');
+    }
+
+    if ($result === false) {
+        throw new Exception("Gagal berkomunikasi dengan API Telegram.");
+    }
+
+    json_response('success', $result);
+
+} catch (Exception $e) {
+    json_response('error', $e->getMessage());
+}

--- a/core/TelegramAPI.php
+++ b/core/TelegramAPI.php
@@ -54,4 +54,32 @@ class TelegramAPI {
         ];
         return $this->apiRequest('sendMessage', $data);
     }
+
+    /**
+     * Mengatur URL webhook untuk menerima update.
+     *
+     * @param string $url URL webhook.
+     * @return mixed Hasil dari API Telegram.
+     */
+    public function setWebhook($url) {
+        return $this->apiRequest('setWebhook', ['url' => $url]);
+    }
+
+    /**
+     * Mendapatkan informasi webhook saat ini.
+     *
+     * @return mixed Hasil dari API Telegram.
+     */
+    public function getWebhookInfo() {
+        return $this->apiRequest('getWebhookInfo');
+    }
+
+    /**
+     * Menghapus webhook yang sudah ter-set.
+     *
+     * @return mixed Hasil dari API Telegram.
+     */
+    public function deleteWebhook() {
+        return $this->apiRequest('deleteWebhook');
+    }
 }


### PR DESCRIPTION
Saya telah menambahkan fungsionalitas agar Anda dapat mengelola webhook bot Telegram langsung dari panel admin.

Perubahan ini meliputi:
- Tombol "Edit" pada daftar bot yang mengarah ke halaman manajemen baru.
- Halaman baru (`admin/edit_bot.php`) untuk setiap bot, yang menampilkan tombol untuk mengatur, memeriksa, dan menghapus webhook.
- Skrip backend (`admin/webhook_manager.php`) yang menangani logika webhook menggunakan AJAX, memberikan pengalaman yang mulus bagi Anda tanpa perlu memuat ulang halaman.
- Penambahan metode `setWebhook`, `getWebhookInfo`, dan `deleteWebhook` pada kelas `TelegramAPI`.
- Pembaruan `CHANGELOG.md` untuk mencerminkan fitur-fitur baru ini.