### PR TITLE
refactor: Gunakan ID bot Telegram asli di URL percakapan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Metode baru (`setWebhook`, `getWebhookInfo`, `deleteWebhook`) di kelas `TelegramAPI`.
 
 ### Diubah
-- Struktur URL untuk halaman percakapan (`chat.php`) diubah dari `?id=` menjadi `?bot_id=&chat_id=`. Ini membuat URL lebih deskriptif dan memastikan bahwa setiap percakapan dapat diidentifikasi secara unik hanya dengan ID bot dan ID pengguna Telegram.
+- Struktur URL untuk halaman percakapan (`chat.php`) telah disempurnakan untuk menggunakan ID Bot asli dari Telegram (bagian numerik dari token) sebagai parameter `bot_id`, bukan ID internal database. Perubahan ini membuat URL lebih konsisten dengan bagian lain dari aplikasi dan lebih mudah dibagikan.
 
 ### Diperbaiki
 - URL untuk halaman edit bot dan untuk endpoint webhook sekarang menggunakan ID Bot Telegram asli (misalnya 7715036030) untuk identifikasi yang unik dan dinamis, bukan ID database internal. Ini meningkatkan keandalan dan konsistensi.

--- a/admin/index.php
+++ b/admin/index.php
@@ -34,25 +34,32 @@ if (!$tables_exist) {
 }
 
 // Ambil daftar bot untuk dropdown
-$bots = $pdo->query("SELECT id, name FROM bots ORDER BY name ASC")->fetchAll();
+$bots = $pdo->query("SELECT id, name, token FROM bots ORDER BY name ASC")->fetchAll();
 
 // Dapatkan bot_id yang dipilih dari URL, jika ada
-$selected_bot_id = isset($_GET['bot_id']) ? (int)$_GET['bot_id'] : null;
+$selected_telegram_bot_id = isset($_GET['bot_id']) ? (string)$_GET['bot_id'] : null;
 $chats = [];
+$internal_bot_id = null;
 
-if ($selected_bot_id) {
-    // Ambil semua chat untuk bot yang dipilih
-    // Di-join dengan messages untuk mendapatkan pesan terakhir (opsional, untuk penyempurnaan nanti)
-    $stmt = $pdo->prepare(
-        "SELECT c.id, c.chat_id, c.first_name, c.username,
-        (SELECT text FROM messages WHERE chat_id = c.id ORDER BY id DESC LIMIT 1) as last_message,
-        (SELECT telegram_timestamp FROM messages WHERE chat_id = c.id ORDER BY id DESC LIMIT 1) as last_message_time
-        FROM chats c
-        WHERE c.bot_id = ?
-        ORDER BY last_message_time DESC"
-    );
-    $stmt->execute([$selected_bot_id]);
-    $chats = $stmt->fetchAll();
+if ($selected_telegram_bot_id) {
+    // Cari ID internal bot berdasarkan ID bot telegram
+    $stmt = $pdo->prepare("SELECT id FROM bots WHERE token LIKE ?");
+    $stmt->execute([$selected_telegram_bot_id . ':%']);
+    $internal_bot_id = $stmt->fetchColumn();
+
+    if ($internal_bot_id) {
+        // Ambil semua chat untuk bot yang dipilih
+        $stmt = $pdo->prepare(
+            "SELECT c.id, c.chat_id, c.first_name, c.username,
+            (SELECT text FROM messages WHERE chat_id = c.id ORDER BY id DESC LIMIT 1) as last_message,
+            (SELECT telegram_timestamp FROM messages WHERE chat_id = c.id ORDER BY id DESC LIMIT 1) as last_message_time
+            FROM chats c
+            WHERE c.bot_id = ?
+            ORDER BY last_message_time DESC"
+        );
+        $stmt->execute([$internal_bot_id]);
+        $chats = $stmt->fetchAll();
+    }
 }
 
 ?>
@@ -95,7 +102,8 @@ if ($selected_bot_id) {
                 <select name="bot_id" id="bot_id" onchange="this.form.submit()">
                     <option value="">-- Pilih Bot --</option>
                     <?php foreach ($bots as $bot): ?>
-                        <option value="<?= $bot['id'] ?>" <?= ($selected_bot_id == $bot['id']) ? 'selected' : '' ?>>
+                        <?php $telegram_bot_id = explode(':', $bot['token'])[0]; ?>
+                        <option value="<?= $telegram_bot_id ?>" <?= ($selected_telegram_bot_id == $telegram_bot_id) ? 'selected' : '' ?>>
                             <?= htmlspecialchars($bot['name']) ?>
                         </option>
                     <?php endforeach; ?>
@@ -103,30 +111,33 @@ if ($selected_bot_id) {
             </form>
         </div>
 
-        <?php if ($selected_bot_id): ?>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Nama Pengguna</th>
-                        <th>Username</th>
-                        <th>Pesan Terakhir</th>
-                        <th>Waktu</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php if (empty($chats)): ?>
+        <?php if ($selected_telegram_bot_id): ?>
+            <?php if (!$internal_bot_id): ?>
+                <p>Bot dengan ID <?= htmlspecialchars($selected_telegram_bot_id) ?> tidak ditemukan.</p>
+            <?php else: ?>
+                <table>
+                    <thead>
                         <tr>
-                            <td colspan="4">Belum ada percakapan untuk bot ini.</td>
+                            <th>Nama Pengguna</th>
+                            <th>Username</th>
+                            <th>Pesan Terakhir</th>
+                            <th>Waktu</th>
                         </tr>
-                    <?php else: ?>
-                        <?php foreach ($chats as $chat): ?>
+                    </thead>
+                    <tbody>
+                        <?php if (empty($chats)): ?>
                             <tr>
-                                <td>
-                                    <a href="chat.php?bot_id=<?= $selected_bot_id ?>&chat_id=<?= $chat['chat_id'] ?>">
-                                        <?= htmlspecialchars($chat['first_name']) ?>
-                                    </a>
-                                </td>
-                                <td>@<?= htmlspecialchars($chat['username']) ?></td>
+                                <td colspan="4">Belum ada percakapan untuk bot ini.</td>
+                            </tr>
+                        <?php else: ?>
+                            <?php foreach ($chats as $chat): ?>
+                                <tr>
+                                    <td>
+                                        <a href="chat.php?bot_id=<?= $selected_telegram_bot_id ?>&chat_id=<?= $chat['chat_id'] ?>">
+                                            <?= htmlspecialchars($chat['first_name']) ?>
+                                        </a>
+                                    </td>
+                                    <td>@<?= htmlspecialchars($chat['username']) ?></td>
                                 <td class="last-message"><?= htmlspecialchars(mb_strimwidth($chat['last_message'], 0, 50, "...")) ?></td>
                                 <td><?= htmlspecialchars($chat['last_message_time']) ?></td>
                             </tr>


### PR DESCRIPTION
Saya telah merefaktorisasi implementasi URL percakapan untuk menggunakan ID bot asli dari Telegram (bagian numerik dari token) sebagai parameter `bot_id` di URL, bukan ID database internal.

Saya melakukan perubahan ini berdasarkan masukan Anda untuk memastikan konsistensi dengan bagian lain dari aplikasi, seperti halaman "Edit Bot".

- Saya memperbarui `admin/index.php` untuk mengambil dan menggunakan ID bot Telegram di dropdown dan tautan.
- Saya memperbarui `admin/chat.php` untuk mencari ID bot internal berdasarkan ID bot Telegram yang diberikan di URL.
- Saya memperbarui `CHANGELOG.md` untuk mencerminkan perubahan ini dengan lebih akurat.