### PR TITLE
fix: Perbaiki kesalahan sintaks di admin/index.php

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -145,6 +145,7 @@ if ($selected_telegram_bot_id) {
                     <?php endif; ?>
                 </tbody>
             </table>
+            <?php endif; ?>
         <?php else: ?>
             <p>Silakan pilih bot untuk melihat percakapannya.</p>
         <?php endif; ?>


### PR DESCRIPTION
Memperbaiki kesalahan parse PHP (unexpected token "else") di `admin/index.php` yang disebabkan oleh blok `<?php endif; ?>` yang hilang.

Kesalahan ini muncul setelah refactoring sebelumnya untuk menambahkan logika pengecekan bot. Blok `endif` yang hilang sekarang telah ditambahkan untuk menutup blok `if (!$internal_bot_id)` dengan benar.