### PR TITLE
fix: Ensure member record exists for all users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.9.0] - 2025-08-10
+
+### Diperbaiki
+- Bug kritis di mana token login tidak disimpan untuk pengguna yang sudah ada (yang berinteraksi dengan bot sebelum sistem member ditambahkan). Sistem sekarang memastikan setiap pengguna memiliki record member sebelum memproses pesan.
+
 ## [1.8.0] - 2025-08-10
 
 ### Ditambahkan

--- a/webhook.php
+++ b/webhook.php
@@ -79,11 +79,15 @@ try {
         $stmt->execute([$internal_bot_id, $chat_id_from_telegram, $first_name, $username]);
         $internal_chat_id = $pdo->lastInsertId();
         app_log("Chat baru dibuat untuk chat_id: {$chat_id_from_telegram}, user: {$first_name}", 'bot');
+    }
 
-        // --- Tambahan: Buat entri member jika belum ada ---
+    // --- 4.5. Pastikan entri member ada (untuk pengguna lama & baru) ---
+    $stmt = $pdo->prepare("SELECT id FROM members WHERE chat_id = ?");
+    $stmt->execute([$internal_chat_id]);
+    if (!$stmt->fetch()) {
         $stmt = $pdo->prepare("INSERT INTO members (chat_id) VALUES (?)");
         $stmt->execute([$internal_chat_id]);
-        app_log("Member baru dibuat untuk chat_id: {$chat_id_from_telegram}", 'bot');
+        app_log("Member record dibuat untuk pengguna lama/baru. chat_id: {$internal_chat_id}", 'bot');
     }
 
     // --- 5. Simpan pesan ke tabel 'messages' ---


### PR DESCRIPTION
This commit fixes a critical bug where login tokens were not being saved for users who existed before the member system was implemented.

The logic in `webhook.php` has been updated to check for the existence of a member record for every incoming message. If a record is not found (which can happen for older users), it is created automatically within the same database transaction. This ensures that the `members` table is always in sync with the `chats` table and that the `/login` command functions correctly for all users.