### PR TITLE
fix: Tangani nilai NULL pada htmlspecialchars di halaman pengguna

### DIFF
--- a/admin/users.php
+++ b/admin/users.php
@@ -134,10 +134,10 @@ function get_sort_link($column, $current_sort, $current_order) {
                     <tr>
                         <td><?= htmlspecialchars($user['id']) ?></td>
                         <td><?= htmlspecialchars($user['telegram_id']) ?></td>
-                        <td><?= htmlspecialchars($user['first_name']) ?></td>
-                        <td><?= htmlspecialchars($user['last_name']) ?></td>
-                        <td>@<?= htmlspecialchars($user['username']) ?></td>
-                        <td><?= htmlspecialchars($user['language_code']) ?></td>
+                        <td><?= htmlspecialchars($user['first_name'] ?? '') ?></td>
+                        <td><?= htmlspecialchars($user['last_name'] ?? '') ?></td>
+                        <td>@<?= htmlspecialchars($user['username'] ?? '') ?></td>
+                        <td><?= htmlspecialchars($user['language_code'] ?? '') ?></td>
                         <td><?= htmlspecialchars($user['created_at']) ?></td>
                         <td colspan="2">
                             <?php


### PR DESCRIPTION
Memperbaiki 'Deprecated: htmlspecialchars(): Passing null to parameter #1' dengan menggunakan null coalescing operator (`?? ''`).

Ini memastikan bahwa jika ada nilai `NULL` dari database untuk kolom seperti `first_name`, `last_name`, `username`, atau `language_code`, string kosong akan diteruskan ke `htmlspecialchars` sebagai gantinya, sehingga mencegah pesan notice pada versi PHP yang lebih baru.