### PR TITLE
fix: Ganti nama foreign key constraint untuk menghindari duplikasi

### DIFF
--- a/migrations/004_fix_members_table.sql
+++ b/migrations/004_fix_members_table.sql
@@ -7,6 +7,6 @@ ALTER TABLE `members`
   DROP FOREIGN KEY `members_ibfk_1`,
   CHANGE `chat_id` `user_id` INT(11) NOT NULL COMMENT 'Referensi ke tabel users',
   ADD UNIQUE KEY `user_id` (`user_id`),
-  ADD CONSTRAINT `members_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE;
+  ADD CONSTRAINT `fk_members_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE;
 
 SET FOREIGN_KEY_CHECKS = 1;

--- a/setup.sql
+++ b/setup.sql
@@ -94,7 +94,7 @@ CREATE TABLE `members` (
   `token_used` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `user_id` (`user_id`),
-  CONSTRAINT `members_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
+  CONSTRAINT `fk_members_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- PERHATIAN:


### PR DESCRIPTION
Memperbaiki error migrasi 'Duplicate FOREIGN KEY constraint name' pada `004_fix_members_table.sql`.

Nama constraint `members_ibfk_1` diubah menjadi `fk_members_user_id` yang lebih unik dan deskriptif untuk mencegah konflik nama saat migrasi dijalankan.

File `setup.sql` juga diperbarui agar konsisten.