### PR TITLE
feat: Implement media marketplace feature

### DIFF
--- a/migrations/008_add_marketplace_features.sql
+++ b/migrations/008_add_marketplace_features.sql
@@ -1,0 +1,40 @@
+-- Migration: Menambahkan fitur marketplace media
+-- Dijalankan pada: 2025-08-11
+-- Deskripsi:
+-- 1. Menambahkan kolom `balance` ke tabel `users` untuk sistem saldo internal.
+-- 2. Menambahkan kolom `state` dan `state_context` ke `rel_user_bot` untuk mengelola percakapan multi-langkah.
+-- 3. Membuat tabel `media_packages` untuk mendefinisikan item yang dijual.
+-- 4. Menambahkan kolom `package_id` ke `media_files` untuk menghubungkan file ke paketnya.
+
+-- 1. Tambah kolom saldo ke tabel pengguna
+ALTER TABLE `users` ADD `balance` DECIMAL(15, 2) NOT NULL DEFAULT 0.00 COMMENT 'Saldo internal pengguna' AFTER `role`;
+
+-- 2. Tambah kolom state untuk conversation handling
+ALTER TABLE `rel_user_bot`
+ADD `state` VARCHAR(50) NULL DEFAULT NULL COMMENT 'Status percakapan pengguna saat ini (mis: awaiting_price)' AFTER `last_interaction_at`,
+ADD `state_context` JSON NULL COMMENT 'Data sementara terkait state (mis: media_group_id yang sedang dikirim)' AFTER `state`;
+
+-- 3. Buat tabel untuk paket media yang dijual
+CREATE TABLE `media_packages` (
+  `id` BIGINT AUTO_INCREMENT PRIMARY KEY,
+  `seller_user_id` INT(11) NOT NULL COMMENT 'Referensi ke tabel users (penjual)',
+  `bot_id` INT(11) NOT NULL COMMENT 'Referensi ke tabel bots',
+  `description` TEXT NULL COMMENT 'Deskripsi paket media',
+  `price` DECIMAL(15, 2) NOT NULL DEFAULT 0.00,
+  `status` ENUM('pending', 'available', 'sold', 'delisted') NOT NULL DEFAULT 'pending' COMMENT 'Status paket penjualan',
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+  KEY `seller_user_id` (`seller_user_id`),
+  KEY `bot_id` (`bot_id`),
+  CONSTRAINT `fk_package_seller` FOREIGN KEY (`seller_user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_package_bot` FOREIGN KEY (`bot_id`) REFERENCES `bots` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Menyimpan informasi paket media yang dijual.';
+
+-- 4. Modifikasi tabel media_files untuk menautkan ke paket
+ALTER TABLE `media_files`
+ADD `package_id` BIGINT NULL DEFAULT NULL COMMENT 'Referensi ke media_packages' AFTER `message_id`,
+ADD KEY `package_id` (`package_id`);
+
+-- Menambahkan foreign key constraint secara terpisah untuk memastikan tabel sudah ada
+ALTER TABLE `media_files`
+ADD CONSTRAINT `fk_media_package` FOREIGN KEY (`package_id`) REFERENCES `media_packages` (`id`) ON DELETE SET NULL;

--- a/webhook.php
+++ b/webhook.php
@@ -110,145 +110,247 @@ $message_date = date('Y-m-d H:i:s', $timestamp);
 try {
     $pdo->beginTransaction();
 
-    // --- Cari atau buat pengguna di tabel 'users' ---
-    $stmt = $pdo->prepare("SELECT id FROM users WHERE telegram_id = ?");
-    $stmt->execute([$user_id_from_telegram]);
-    $user = $stmt->fetch();
+    // --- Cari atau buat pengguna, dapatkan data lengkap termasuk state dan saldo ---
+    $stmt_user = $pdo->prepare(
+        "SELECT u.id, u.telegram_id, u.role, u.balance, r.state, r.state_context
+         FROM users u
+         LEFT JOIN rel_user_bot r ON u.id = r.user_id AND r.bot_id = ?
+         WHERE u.telegram_id = ?"
+    );
+    $stmt_user->execute([$internal_bot_id, $user_id_from_telegram]);
+    $current_user = $stmt_user->fetch();
 
-    if ($user) {
-        $internal_user_id = $user['id'];
+    if ($current_user) {
+        $internal_user_id = $current_user['id'];
     } else {
-        $stmt = $pdo->prepare("INSERT INTO users (telegram_id, first_name, username, role) VALUES (?, ?, ?, ?)");
-        // Berikan peran admin jika ID cocok dengan SUPER_ADMIN, jika tidak 'user'
+        // Buat pengguna baru jika tidak ditemukan
         $initial_role = (defined('SUPER_ADMIN_TELEGRAM_ID') && (string)$user_id_from_telegram === (string)SUPER_ADMIN_TELEGRAM_ID) ? 'admin' : 'user';
-        $stmt->execute([$user_id_from_telegram, $first_name, $username, $initial_role]);
+        $stmt_insert = $pdo->prepare("INSERT INTO users (telegram_id, first_name, username, role) VALUES (?, ?, ?, ?)");
+        $stmt_insert->execute([$user_id_from_telegram, $first_name, $username, $initial_role]);
         $internal_user_id = $pdo->lastInsertId();
+
+        // Ambil kembali data pengguna yang baru dibuat
+        $stmt_user->execute([$internal_bot_id, $user_id_from_telegram]);
+        $current_user = $stmt_user->fetch();
         app_log("Pengguna baru dibuat: telegram_id: {$user_id_from_telegram}, user: {$first_name}, peran: {$initial_role}", 'bot');
     }
 
-    // --- Bootstrap Super Admin untuk pengguna yang sudah ada ---
-    if (defined('SUPER_ADMIN_TELEGRAM_ID') && !empty(SUPER_ADMIN_TELEGRAM_ID) && (string)$user_id_from_telegram === (string)SUPER_ADMIN_TELEGRAM_ID) {
-        $stmt_role = $pdo->prepare("SELECT role FROM users WHERE id = ?");
-        $stmt_role->execute([$internal_user_id]);
-        if ($stmt_role->fetchColumn() !== 'admin') {
-            $stmt_update_role = $pdo->prepare("UPDATE users SET role = 'admin' WHERE id = ?");
-            $stmt_update_role->execute([$internal_user_id]);
-            app_log("Peran admin diberikan kepada super admin yang sudah ada: {$user_id_from_telegram}", 'bot');
+    // --- Bootstrap Super Admin, pastikan relasi user-bot dan entri member ada ---
+    if ($current_user) {
+        if (defined('SUPER_ADMIN_TELEGRAM_ID') && !empty(SUPER_ADMIN_TELEGRAM_ID) && (string)$user_id_from_telegram === (string)SUPER_ADMIN_TELEGRAM_ID) {
+            if ($current_user['role'] !== 'admin') {
+                $pdo->prepare("UPDATE users SET role = 'admin' WHERE id = ?")->execute([$internal_user_id]);
+                $current_user['role'] = 'admin';
+                app_log("Peran admin diberikan kepada super admin: {$user_id_from_telegram}", 'bot');
+            }
+        }
+        // Pastikan relasi user-bot ada (jika tidak ada, state akan null)
+        if ($current_user['state'] === null) {
+            $pdo->prepare("INSERT INTO rel_user_bot (user_id, bot_id) VALUES (?, ?) ON DUPLICATE KEY UPDATE user_id=user_id")->execute([$internal_user_id, $internal_bot_id]);
+        }
+        // Pastikan entri member ada
+        $stmt_member = $pdo->prepare("SELECT id FROM members WHERE user_id = ?");
+        $stmt_member->execute([$internal_user_id]);
+        if (!$stmt_member->fetch()) {
+            $pdo->prepare("INSERT INTO members (user_id) VALUES (?)")->execute([$internal_user_id]);
         }
     }
 
-    // --- Pastikan relasi user-bot dan entri member ada ---
-    $stmt = $pdo->prepare("SELECT id FROM rel_user_bot WHERE user_id = ? AND bot_id = ?");
-    $stmt->execute([$internal_user_id, $internal_bot_id]);
-    if (!$stmt->fetch()) {
-        $stmt = $pdo->prepare("INSERT INTO rel_user_bot (user_id, bot_id) VALUES (?, ?)");
-        $stmt->execute([$internal_user_id, $internal_bot_id]);
-    }
-    $stmt = $pdo->prepare("SELECT id FROM members WHERE user_id = ?");
-    $stmt->execute([$internal_user_id]);
-    if (!$stmt->fetch()) {
-        $stmt = $pdo->prepare("INSERT INTO members (user_id) VALUES (?)");
-        $stmt->execute([$internal_user_id]);
-    }
+    // --- Simpan pesan ke tabel 'messages' ---
+    $pdo->prepare("INSERT INTO messages (user_id, bot_id, telegram_message_id, text, raw_data, direction, telegram_timestamp) VALUES (?, ?, ?, ?, ?, 'incoming', ?)")
+        ->execute([$internal_user_id, $internal_bot_id, $telegram_message_id, $text_content, $update_json, $message_date]);
 
-    // --- Simpan pesan ke tabel 'messages' (termasuk raw_data) ---
-    $stmt = $pdo->prepare(
-        "INSERT INTO messages (user_id, bot_id, telegram_message_id, text, raw_data, direction, telegram_timestamp) VALUES (?, ?, ?, ?, ?, 'incoming', ?)"
-    );
-    $stmt->execute([$internal_user_id, $internal_bot_id, $telegram_message_id, $text_content, $update_json, $message_date]);
-
-    // --- Simpan file media jika ada ---
-    if ($is_media && isset($update['message'])) { // Pastikan ini adalah pesan media asli
-        try {
-            $media_type = null;
-            $media_info = null;
-
-            $media_keys = ['photo', 'video', 'audio', 'voice', 'document', 'video_note', 'animation'];
-            foreach ($media_keys as $key) {
-                if (isset($update['message'][$key])) {
-                    $media_type = $key;
-                    $media_info = ($key === 'photo') ? end($update['message']['photo']) : $update['message'][$key];
-                    break;
-                }
-            }
-
-            if ($media_type && $media_info) {
-                $sql = "INSERT INTO media_files (
-                            file_id, file_unique_id, type, file_size, width, height, duration,
-                            mime_type, file_name, caption, caption_entities, user_id, chat_id,
-                            message_id, media_group_id, performer, title, has_spoiler, is_animated
-                        ) VALUES (
-                            :file_id, :file_unique_id, :type, :file_size, :width, :height, :duration,
-                            :mime_type, :file_name, :caption, :caption_entities, :user_id, :chat_id,
-                            :message_id, :media_group_id, :performer, :title, :has_spoiler, :is_animated
-                        )";
-
-                $stmt_media = $pdo->prepare($sql);
-
-                $stmt_media->execute([
-                    ':file_id' => $media_info['file_id'],
-                    ':file_unique_id' => $media_info['file_unique_id'],
-                    ':type' => $media_type,
-                    ':file_size' => $media_info['file_size'] ?? null,
-                    ':width' => $media_info['width'] ?? ($media_type === 'video_note' ? ($media_info['length'] ?? null) : null),
-                    ':height' => $media_info['height'] ?? ($media_type === 'video_note' ? ($media_info['length'] ?? null) : null),
-                    ':duration' => $media_info['duration'] ?? null,
-                    ':mime_type' => $media_info['mime_type'] ?? null,
-                    ':file_name' => $media_info['file_name'] ?? null,
-                    ':caption' => $update['message']['caption'] ?? null,
-                    ':caption_entities' => isset($update['message']['caption_entities']) ? json_encode($update['message']['caption_entities']) : null,
-                    ':user_id' => $update['message']['from']['id'],
-                    ':chat_id' => $update['message']['chat']['id'],
-                    ':message_id' => $update['message']['message_id'],
-                    ':media_group_id' => $update['message']['media_group_id'] ?? null,
-                    ':performer' => $media_info['performer'] ?? null,
-                    ':title' => $media_info['title'] ?? null,
-                    ':has_spoiler' => $update['message']['has_media_spoiler'] ?? false,
-                    ':is_animated' => $media_info['is_animated'] ?? ($media_type === 'animation'),
-                ]);
-
-                app_log("Media {$media_type} dari chat_id: {$update['message']['chat']['id']} disimpan ke media_files.", 'bot');
-            }
-        } catch (Exception $media_exception) {
-            app_log("Gagal menyimpan detail media: " . $media_exception->getMessage(), 'database');
-        }
-    }
-
-    // --- Handle perintah ---
+    // ===============================================================
+    // =========== BLOK LOGIKA APLIKASI MARKETPLACE DIMULAI ==========
+    // ===============================================================
     $telegram_api = new TelegramAPI($bot_token);
-    // Perintah hanya dieksekusi jika itu adalah pesan teks baru
-    if (isset($update['message']['text'])) {
-        $text_for_command = $update['message']['text'];
 
-        if ($text_for_command === '/start') {
-            $reply_text = "Selamat datang! Silakan kirim pesan Anda, dan admin kami akan segera merespons.";
-            $telegram_api->sendMessage($chat_id_from_telegram, $reply_text);
-            app_log("Perintah /start dieksekusi untuk chat_id: {$chat_id_from_telegram}", 'bot');
-        } elseif ($text_for_command === '/login') {
-            app_log("Perintah /login diterima dari chat_id: {$chat_id_from_telegram}", 'bot');
+    // Fungsi helper untuk mengubah state pengguna
+    function setUserState($pdo, $user_id, $bot_id, $state, $context = null) {
+        $stmt = $pdo->prepare("UPDATE rel_user_bot SET state = ?, state_context = ? WHERE user_id = ? AND bot_id = ?");
+        $stmt->execute([$state, $context ? json_encode($context) : null, $user_id, $bot_id]);
+    }
 
-            if (!defined('BASE_URL') || empty(BASE_URL)) {
-                app_log("Pembuatan token gagal: BASE_URL tidak terdefinisi. Chat ID: {$chat_id_from_telegram}", 'error');
-                $telegram_api->sendMessage($chat_id_from_telegram, "Maaf, terjadi kesalahan teknis (ERR:CFG01). Tidak dapat membuat link login saat ini.");
-            } else {
-                try {
-                    $login_token = bin2hex(random_bytes(32));
-                    $token_creation_time = date('Y-m-d H:i:s');
+    // 1. HANDLE STATE-BASED CONVERSATION (PRIORITAS TERTINGGI)
+    if ($current_user['state'] !== null && $update_type === 'message' && isset($message_context['text'])) {
+        $text = $message_context['text'];
+        $state_context = json_decode($current_user['state_context'] ?? '{}', true);
 
-                    $stmt = $pdo->prepare("UPDATE members SET login_token = ?, token_created_at = ?, token_used = 0 WHERE user_id = ?");
-                    $stmt->execute([$login_token, $token_creation_time, $internal_user_id]);
+        if ($text === '/cancel') {
+            setUserState($pdo, $internal_user_id, $internal_bot_id, null, null);
+            $telegram_api->sendMessage($chat_id_from_telegram, "Operasi dibatalkan.");
+            $pdo->commit(); exit;
+        }
 
-                    app_log("Token login berhasil dibuat untuk user_id: {$internal_user_id}", 'bot');
-
-                    $login_link = rtrim(BASE_URL, '/') . '/member/index.php?token=' . $login_token;
-                    $reply_text = "Klik tombol di bawah ini untuk masuk ke Panel Member Anda.\n\nTombol ini hanya dapat digunakan satu kali.";
-                    $keyboard = ['inline_keyboard' => [[['text' => 'Login ke Panel Member', 'url' => $login_link]]]];
-                    $telegram_api->sendMessage($chat_id_from_telegram, $reply_text, null, json_encode($keyboard));
-
-                } catch (Exception $e) {
-                    app_log("Pembuatan token gagal (DB Error): " . $e->getMessage() . ". Chat ID: {$chat_id_from_telegram}", 'database');
-                    $telegram_api->sendMessage($chat_id_from_telegram, "Maaf, terjadi kesalahan teknis (ERR:DB01). Gagal membuat token login.");
+        switch ($current_user['state']) {
+            case 'awaiting_price':
+                if (is_numeric($text) && $text > 0) {
+                    $price = (float)$text;
+                    $package_id = $state_context['package_id'];
+                    $pdo->prepare("UPDATE media_packages SET price = ?, status = 'available' WHERE id = ? AND seller_user_id = ?")->execute([$price, $package_id, $internal_user_id]);
+                    setUserState($pdo, $internal_user_id, $internal_bot_id, null, null);
+                    $telegram_api->sendMessage($chat_id_from_telegram, "✅ Harga telah ditetapkan. Paket media Anda dengan ID #{$package_id} sekarang tersedia untuk dijual.");
+                } else {
+                    $telegram_api->sendMessage($chat_id_from_telegram, "⚠️ Harga tidak valid. Harap masukkan angka saja (contoh: 50000).");
                 }
+                $pdo->commit(); exit;
+
+            case 'awaiting_description':
+                $package_id = $state_context['package_id'];
+                $pdo->prepare("UPDATE media_packages SET description = ? WHERE id = ? AND seller_user_id = ?")->execute([$text, $package_id, $internal_user_id]);
+                setUserState($pdo, $internal_user_id, $internal_bot_id, 'awaiting_price', ['package_id' => $package_id]);
+                $telegram_api->sendMessage($chat_id_from_telegram, "📝 Deskripsi disimpan. Sekarang, berapa harga untuk paket ini? (Contoh: 50000)");
+                $pdo->commit(); exit;
+        }
+    }
+
+    // 2. HANDLE MEDIA SUBMISSION (SELLER FLOW)
+    if ($is_media && isset($update['message'])) {
+        // Simpan file media (logika asli)
+        $media_type = null; $media_info = null;
+        $media_keys = ['photo', 'video', 'audio', 'voice', 'document', 'animation', 'video_note'];
+        foreach ($media_keys as $key) { if (isset($update['message'][$key])) { $media_type = $key; $media_info = ($key === 'photo') ? end($update['message']['photo']) : $update['message'][$key]; break; } }
+        if ($media_type && $media_info) {
+            $sql = "INSERT INTO media_files (file_id, file_unique_id, type, file_size, width, height, duration, mime_type, file_name, caption, caption_entities, user_id, chat_id, message_id, media_group_id, has_spoiler) VALUES (:file_id, :file_unique_id, :type, :file_size, :width, :height, :duration, :mime_type, :file_name, :caption, :caption_entities, :user_id, :chat_id, :message_id, :media_group_id, :has_spoiler)";
+            $stmt_media = $pdo->prepare($sql);
+            $stmt_media->execute([':file_id' => $media_info['file_id'], ':file_unique_id' => $media_info['file_unique_id'], ':type' => $media_type, ':file_size' => $media_info['file_size'] ?? null, ':width' => $media_info['width'] ?? null, ':height' => $media_info['height'] ?? null, ':duration' => $media_info['duration'] ?? null, ':mime_type' => $media_info['mime_type'] ?? null, ':file_name' => $media_info['file_name'] ?? null, ':caption' => $update['message']['caption'] ?? null, ':caption_entities' => isset($update['message']['caption_entities']) ? json_encode($update['message']['caption_entities']) : null, ':user_id' => $user_id_from_telegram, ':chat_id' => $chat_id_from_telegram, ':message_id' => $telegram_message_id, ':media_group_id' => $update['message']['media_group_id'] ?? null, ':has_spoiler' => $update['message']['has_media_spoiler'] ?? false]);
+            $last_media_insert_id = $pdo->lastInsertId();
+
+            // Logika baru untuk alur penjualan
+            if ($current_user['state'] !== 'awaiting_media') {
+                 $stmt_package = $pdo->prepare("INSERT INTO media_packages (seller_user_id, bot_id, status) VALUES (?, ?, 'pending')");
+                 $stmt_package->execute([$internal_user_id, $internal_bot_id]);
+                 $package_id = $pdo->lastInsertId();
+                 setUserState($pdo, $internal_user_id, $internal_bot_id, 'awaiting_media', ['package_id' => $package_id]);
+                 $telegram_api->sendMessage($chat_id_from_telegram, "📥 Media pertama diterima. Kirim lebih banyak file jika bagian dari satu paket, atau kirim /done jika selesai.");
+            }
+            $state_context = json_decode($current_user['state_context'] ?? '{}', true);
+            if(isset($state_context['package_id'])){
+                $pdo->prepare("UPDATE media_files SET package_id = ? WHERE id = ?")->execute([$state_context['package_id'], $last_media_insert_id]);
+            }
+        }
+        $pdo->commit(); exit;
+    }
+
+    // 3. HANDLE CALLBACK QUERIES (BUYER FLOW)
+    if ($update_type === 'callback_query') {
+        $callback_data = $update['callback_query']['data'];
+        $callback_query_id = $update['callback_query']['id'];
+
+        if (strpos($callback_data, 'buy_') === 0) {
+            $package_id = substr($callback_data, strlen('buy_'));
+
+            $stmt_pkg = $pdo->prepare("SELECT price, seller_user_id FROM media_packages WHERE id = ? AND status = 'available'");
+            $stmt_pkg->execute([$package_id]);
+            $package = $stmt_pkg->fetch();
+
+            if ($package && $current_user['balance'] >= $package['price']) {
+                // Proses transaksi
+                $new_balance = $current_user['balance'] - $package['price'];
+                $pdo->prepare("UPDATE users SET balance = ? WHERE id = ?")->execute([$new_balance, $internal_user_id]);
+                $pdo->prepare("UPDATE users SET balance = balance + ? WHERE id = ?")->execute([$package['price'], $package['seller_user_id']]);
+                $pdo->prepare("UPDATE media_packages SET status = 'sold' WHERE id = ?")->execute([$package_id]);
+
+                // Kirim media
+                $stmt_files = $pdo->prepare("SELECT file_id, type, caption FROM media_files WHERE package_id = ? ORDER BY id");
+                $stmt_files->execute([$package_id]);
+                $files = $stmt_files->fetchAll();
+
+                $media_group = [];
+                foreach ($files as $file) {
+                    $media_group[] = ['type' => $file['type'], 'media' => $file['file_id']];
+                }
+                if (!empty($media_group)) {
+                    $media_group[0]['caption'] = "Terima kasih telah membeli! (ID Paket: #{$package_id})";
+                    $telegram_api->sendMediaGroup($chat_id_from_telegram, json_encode($media_group));
+                }
+
+                $telegram_api->apiRequest('answerCallbackQuery', ['callback_query_id' => $callback_query_id, 'text' => 'Pembelian berhasil!']);
+            } else {
+                $telegram_api->apiRequest('answerCallbackQuery', ['callback_query_id' => $callback_query_id, 'text' => 'Pembelian gagal. Saldo tidak cukup atau item tidak tersedia.', 'show_alert' => true]);
+            }
+        }
+        $pdo->commit(); exit;
+    }
+
+    // 4. HANDLE TEXT MESSAGES (COMMANDS)
+    if ($update_type === 'message' && isset($message_context['text'])) {
+        $text = $message_context['text'];
+        $is_admin = ($current_user['role'] === 'admin');
+
+        // Perintah Admin
+        if ($is_admin) {
+            if (strpos($text, '/dev_addsaldo') === 0) {
+                $parts = explode(' ', $text);
+                if (count($parts) === 3 && is_numeric($parts[1]) && is_numeric($parts[2])) {
+                    $pdo->prepare("UPDATE users SET balance = balance + ? WHERE telegram_id = ?")->execute([(float)$parts[2], $parts[1]]);
+                    $telegram_api->sendMessage($chat_id_from_telegram, "✅ Saldo untuk {$parts[1]} berhasil ditambahkan sebesar {$parts[2]}.");
+                } else { $telegram_api->sendMessage($chat_id_from_telegram, "Format salah. Gunakan: /dev_addsaldo <telegram_id> <jumlah>"); }
+                $pdo->commit(); exit;
+            }
+            if (strpos($text, '/feature') === 0) {
+                $parts = explode(' ', $text);
+                if (count($parts) === 3 && is_numeric($parts[1]) && is_numeric($parts[2])) {
+                    list(, $package_id, $channel_id) = $parts;
+                    $stmt_pkg = $pdo->prepare("SELECT p.description, p.price, f.file_id, f.type FROM media_packages p JOIN media_files f ON p.id = f.package_id WHERE p.id = ? LIMIT 1");
+                    $stmt_pkg->execute([$package_id]);
+                    $pkg_info = $stmt_pkg->fetch();
+                    if($pkg_info) {
+                        $bot_username_stmt = $pdo->prepare("SELECT username FROM bots WHERE id = ?");
+                        $bot_username_stmt->execute([$internal_bot_id]);
+                        $bot_username = $bot_username_stmt->fetchColumn();
+
+                        $price_formatted = number_format($pkg_info['price'], 0, ',', '.');
+                        $caption = "✨ **Item Unggulan!** ✨\n\n{$pkg_info['description']}\n\nHarga: **Rp {$price_formatted}**";
+                        $keyboard = ['inline_keyboard' => [[['text' => '➡️ Lihat & Beli di Bot', 'url' => "https://t.me/{$bot_username}?start=package_{$package_id}"]]]];
+                        $telegram_api->sendPhoto($channel_id, $pkg_info['file_id'], $caption, 'Markdown', json_encode($keyboard));
+                        $telegram_api->sendMessage($chat_id_from_telegram, "✅ Item #{$package_id} berhasil di-feature ke channel {$channel_id}.");
+                    } else { $telegram_api->sendMessage($chat_id_from_telegram, "Item #{$package_id} tidak ditemukan."); }
+                } else { $telegram_api->sendMessage($chat_id_from_telegram, "Format salah. Gunakan: /feature <package_id> <channel_id_atau_@username>");}
+                $pdo->commit(); exit;
+            }
+        }
+
+        // Perintah User
+        if (strpos($text, '/start') === 0) {
+            $parts = explode(' ', $text);
+            if (count($parts) > 1 && strpos($parts[1], 'package_') === 0) {
+                $package_id = substr($parts[1], strlen('package_'));
+                $stmt_pkg = $pdo->prepare("SELECT description, price, status FROM media_packages WHERE id = ?");
+                $stmt_pkg->execute([$package_id]);
+                $package = $stmt_pkg->fetch();
+                if($package && $package['status'] == 'available') {
+                    $price_formatted = number_format($package['price'], 0, ',', '.');
+                    $balance_formatted = number_format($current_user['balance'], 0, ',', '.');
+                    $reply_text = "Anda tertarik dengan item berikut:\n\n*Deskripsi:* {$package['description']}\n*Harga:* Rp {$price_formatted}\n\nSaldo Anda saat ini: Rp {$balance_formatted}.";
+                    $keyboard = ['inline_keyboard' => [[['text' => "Beli Sekarang (Rp {$price_formatted})", 'callback_data' => "buy_{$package_id}"]]]];
+                    $telegram_api->sendMessage($chat_id_from_telegram, $reply_text, 'Markdown', json_encode($keyboard));
+                } else { $telegram_api->sendMessage($chat_id_from_telegram, "Maaf, item ini sudah tidak tersedia."); }
+            } else {
+                $telegram_api->sendMessage($chat_id_from_telegram, "Selamat datang di bot marketplace! Gunakan /sell untuk mulai menjual media.");
+            }
+        } elseif ($text === '/sell') {
+            setUserState($pdo, $internal_user_id, $internal_bot_id, 'awaiting_media', null);
+            $telegram_api->sendMessage($chat_id_from_telegram, "Silakan kirim file media (foto/video) yang ingin Anda jual. Jika lebih dari satu, kirim sebagai album. Kirim /done jika sudah selesai.");
+        } elseif ($text === '/done' && $current_user['state'] === 'awaiting_media') {
+            $state_context = json_decode($current_user['state_context'] ?? '{}', true);
+            if(isset($state_context['package_id'])) {
+                $package_id = $state_context['package_id'];
+                setUserState($pdo, $internal_user_id, $internal_bot_id, 'awaiting_description', ['package_id' => $package_id]);
+                $telegram_api->sendMessage($chat_id_from_telegram, "✅ Selesai mengunggah media. Sekarang, tulis deskripsi singkat untuk paket media ini.");
+            } else { $telegram_api->sendMessage($chat_id_from_telegram, "Anda harus mengirim setidaknya satu media terlebih dahulu."); }
+        } elseif ($text === '/balance') {
+            $balance = number_format($current_user['balance'], 2, ',', '.');
+            $telegram_api->sendMessage($chat_id_from_telegram, "Saldo Anda saat ini: Rp {$balance}");
+        } elseif ($text === '/login') {
+            // Logika /login yang sudah ada
+            if (!defined('BASE_URL') || empty(BASE_URL)) { $telegram_api->sendMessage($chat_id_from_telegram, "Maaf, terjadi kesalahan teknis (ERR:CFG01)."); }
+            else {
+                $login_token = bin2hex(random_bytes(32));
+                $pdo->prepare("UPDATE members SET login_token = ?, token_created_at = NOW(), token_used = 0 WHERE user_id = ?")->execute([$login_token, $internal_user_id]);
+                $login_link = rtrim(BASE_URL, '/') . '/member/index.php?token=' . $login_token;
+                $keyboard = ['inline_keyboard' => [[['text' => 'Login ke Panel Member', 'url' => $login_link]]]];
+                $telegram_api->sendMessage($chat_id_from_telegram, "Klik tombol di bawah ini untuk masuk ke Panel Member Anda. Tombol ini hanya dapat digunakan satu kali.", null, json_encode($keyboard));
             }
         }
     }


### PR DESCRIPTION
This commit introduces a media marketplace feature into the existing PHP-based Telegram bot management platform.

The new functionality allows users to act as sellers and buyers:

- **Seller Flow:** Users can send media (photos, videos) to the bot, which groups them into a package. The bot then prompts for a description and price.
- **Buyer Flow:** Admins can "feature" a package to a public channel. A deep link in the post directs users to the bot, where they can purchase the package using an internal balance system. Upon purchase, the bot automatically delivers the media files.
- **Admin Flow:** Admins have commands to manage the system, including adding balance to users for testing (`/dev_addsaldo`) and featuring items (`/feature`).

Key technical changes:
- Added a new database migration (`migrations/008_add_marketplace_features.sql`) to introduce:
  - A `balance` column in the `users` table.
  - A `media_packages` table to define products.
  - `state` and `state_context` columns in `rel_user_bot` for conversation management.
- Overhauled `webhook.php` to include:
  - A state machine for handling multi-step user conversations.
  - Handlers for all new commands and callback queries.
  - Logic for processing sales, updating balances, and delivering digital goods.