### PR TITLE
feat(sell): Overhaul sell command to use reply-to-media flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.2.0] - 2025-08-11
+
+### Diubah
+- **Alur Perintah `/sell`**: Proses penjualan konten dirombak total menjadi lebih intuitif.
+  - Penjual sekarang hanya perlu me-reply media (foto/video/album) dengan perintah `/sell`.
+  - Bot akan secara otomatis menggunakan caption dari media tersebut sebagai deskripsi produk.
+  - Alur multi-langkah yang lama (meminta media, lalu deskripsi) telah dihapus, membuat proses penjualan lebih cepat dan sederhana.
+
 ## [2.1.2] - 2025-08-11
 
 ### Diubah


### PR DESCRIPTION
This commit completely revamps the content selling workflow to make it more intuitive and streamlined, per your request.

The key changes are:
- The old multi-step `/sell` command is removed. The `awaiting_media` and `awaiting_description` states are now obsolete.
- To sell content, you must now reply to a media message (or a message in a media group) with the `/sell` command.
- The bot automatically uses the caption of the replied-to media as the product description.
- Upon a valid `/sell` reply, a new package is created, the relevant media file(s) are linked to it, and the bot immediately asks you to provide a price.
- The media submission process is now passive; the bot simply saves media info and waits for you to initiate a sale.

This new flow significantly simplifies the process for you.