### PR TITLE
feat: Add content thumbnail and preview functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.4.0] - 2025-08-11
+
+### Ditambahkan
+- **Fitur Thumbnail Konten**: Setiap paket konten sekarang memiliki satu media yang ditunjuk sebagai thumbnail.
+- **Callback `view_full_`**: Menambahkan handler callback baru untuk tombol "Lihat Selengkapnya", yang memungkinkan pengguna yang berhak untuk melihat semua media dalam sebuah paket.
+
+### Diubah
+- **Logika Perintah `/sell`**: Perintah `/sell` sekarang secara otomatis menetapkan media yang di-reply sebagai thumbnail untuk paket konten yang baru dibuat.
+- **Logika Perintah `/konten`**: Perintah `/konten` sekarang hanya menampilkan thumbnail pratinjau. Tombol di bawah thumbnail akan berubah secara dinamis: "Beli" untuk pengguna baru, dan "Lihat Selengkapnya" untuk penjual atau pembeli yang sudah ada.
+
 ## [2.3.1] - 2025-08-11
 
 ### Diubah

--- a/migrations/011_add_thumbnail_to_packages.sql
+++ b/migrations/011_add_thumbnail_to_packages.sql
@@ -1,0 +1,7 @@
+-- Migration to add a thumbnail reference to media_packages
+-- Dijalankan pada 2025-08-11
+-- This allows a package to have a designated cover image/video.
+
+ALTER TABLE `media_packages`
+ADD COLUMN `thumbnail_media_id` BIGINT NULL DEFAULT NULL AFTER `description`,
+ADD CONSTRAINT `fk_package_thumbnail` FOREIGN KEY (`thumbnail_media_id`) REFERENCES `media_files`(`id`) ON DELETE SET NULL;


### PR DESCRIPTION
This commit implements a major enhancement to the content selling and viewing process based on your feedback.

Key changes:
- **Thumbnail Support**: A `thumbnail_media_id` has been added to the `media_packages` table via a new migration (`011_add_thumbnail_to_packages.sql`).
- **Updated `/sell` command**: When a seller replies to a media file with `/sell`, that specific file is now designated as the package's thumbnail.
- **Reworked `/konten` command**: This command now acts as a content preview. It sends only the package's thumbnail. Below the thumbnail, an inline button appears:
    - A "Buy" button is shown to anyone who has not purchased the content.
    - A "View Full Content" button is shown to the seller and to anyone who has already purchased it.
- **New `view_full_` callback**: A handler for this new callback has been added. It verifies permissions and sends the complete media group to those who are authorized.