### PR TITLE
Fix: Correct foreign key constraint in sales table migration

### DIFF
--- a/migrations/010_create_sales_table.sql
+++ b/migrations/010_create_sales_table.sql
@@ -4,9 +4,9 @@
 
 CREATE TABLE `sales` (
   `id` BIGINT AUTO_INCREMENT PRIMARY KEY,
-  `package_id` BIGINT NOT NULL,
-  `seller_user_id` BIGINT NOT NULL,
-  `buyer_user_id` BIGINT NOT NULL,
+  `package_id` BIGINT NOT NULL COMMENT 'Referensi ke media_packages.id',
+  `seller_user_id` INT(11) NOT NULL COMMENT 'Referensi ke users.id (penjual)',
+  `buyer_user_id` INT(11) NOT NULL COMMENT 'Referensi ke users.id (pembeli)',
   `price` DECIMAL(15, 2) NOT NULL,
   `purchased_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   KEY `package_id` (`package_id`),


### PR DESCRIPTION
This commit fixes a 'Foreign key constraint is incorrectly formed' error in the `010_create_sales_table.sql` migration file.

The error was caused by a data type mismatch. The `seller_user_id` and `buyer_user_id` columns were defined as `BIGINT`, while the `id` column they reference in the `users` table is `INT(11)`.

This change aligns the data types by changing `BIGINT` to `INT(11)` in the `sales` table definition, ensuring the foreign key constraints can be created successfully.