### PR TITLE
Fix: Add missing include for SaleRepository in MessageHandler

### DIFF
--- a/core/handlers/MessageHandler.php
+++ b/core/handlers/MessageHandler.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once __DIR__ . '/../database/PackageRepository.php';
+require_once __DIR__ . '/../database/SaleRepository.php';
 require_once __DIR__ . '/../database/MediaFileRepository.php'; // Assuming this exists
 
 class MessageHandler


### PR DESCRIPTION
This commit fixes a fatal error 'Class "SaleRepository" not found' that occurred within the MessageHandler.

The error was caused by a missing `require_once` statement for the `SaleRepository.php` file. The handler was attempting to instantiate the class to check if a user has purchased a package, but the class definition had not been loaded.

This change adds the necessary include statement at the top of `core/handlers/MessageHandler.php`, ensuring the `SaleRepository` class is available when needed.