### PR TITLE
Fix: Resolve fatal error in CallbackQueryHandler

### DIFF
--- a/core/TelegramAPI.php
+++ b/core/TelegramAPI.php
@@ -78,6 +78,25 @@ class TelegramAPI {
         return $this->apiRequest('sendMediaGroup', $data);
     }
 
+    /**
+     * Menjawab callback query (misalnya, dari tombol inline).
+     *
+     * @param string $callback_query_id ID dari callback query.
+     * @param string|null $text Teks notifikasi yang akan ditampilkan.
+     * @param bool $show_alert Jika true, notifikasi akan ditampilkan sebagai dialog alert.
+     * @return mixed Hasil dari API Telegram.
+     */
+    public function answerCallbackQuery($callback_query_id, $text = null, $show_alert = false) {
+        $data = [
+            'callback_query_id' => $callback_query_id,
+        ];
+        if ($text) {
+            $data['text'] = $text;
+        }
+        $data['show_alert'] = $show_alert;
+        return $this->apiRequest('answerCallbackQuery', $data);
+    }
+
     // --- Metode untuk mengirim berbagai jenis media ---
 
     public function sendPhoto($chat_id, $photo, $caption = null, $parse_mode = null, $reply_markup = null) {

--- a/core/handlers/CallbackQueryHandler.php
+++ b/core/handlers/CallbackQueryHandler.php
@@ -42,7 +42,7 @@ class CallbackQueryHandler
 
         $package = $this->package_repo->find($package_id);
         if (!$package) {
-            $this->telegram_api->apiRequest('answerCallbackQuery', ['callback_query_id' => $callback_query_id, 'text' => '⚠️ Paket tidak ditemukan.', 'show_alert' => true]);
+            $this->telegram_api->answerCallbackQuery($callback_query_id, '⚠️ Paket tidak ditemukan.', true);
             return;
         }
 
@@ -50,7 +50,7 @@ class CallbackQueryHandler
         $has_purchased = $this->sale_repo->hasUserPurchased($package_id, $internal_user_id);
 
         if ($is_seller || $has_purchased) {
-            $this->telegram_api->apiRequest('answerCallbackQuery', ['callback_query_id' => $callback_query_id, 'text' => '✅ Akses diberikan. Mengirim konten lengkap...']);
+            $this->telegram_api->answerCallbackQuery($callback_query_id, '✅ Akses diberikan. Mengirim konten lengkap...');
 
             $files = $this->package_repo->getPackageFiles($package_id);
             if (!empty($files)) {
@@ -58,7 +58,7 @@ class CallbackQueryHandler
                 $this->telegram_api->sendMediaGroup($this->chat_id, json_encode($media_group));
             }
         } else {
-            $this->telegram_api->apiRequest('answerCallbackQuery', ['callback_query_id' => $callback_query_id, 'text' => '⚠️ Anda tidak memiliki akses ke konten ini.', 'show_alert' => true]);
+            $this->telegram_api->answerCallbackQuery($callback_query_id, '⚠️ Anda tidak memiliki akses ke konten ini.', true);
         }
     }
 
@@ -82,12 +82,12 @@ class CallbackQueryHandler
                     $media_group[0]['caption'] = "Terima kasih telah membeli!\n\n" . ($full_package_details['description'] ?? '');
                     $this->telegram_api->sendMediaGroup($this->chat_id, json_encode($media_group));
                 }
-                $this->telegram_api->apiRequest('answerCallbackQuery', ['callback_query_id' => $callback_query_id, 'text' => 'Pembelian berhasil!']);
+                $this->telegram_api->answerCallbackQuery($callback_query_id, 'Pembelian berhasil!');
             } else {
-                $this->telegram_api->apiRequest('answerCallbackQuery', ['callback_query_id' => $callback_query_id, 'text' => 'Pembelian gagal karena kesalahan internal.', 'show_alert' => true]);
+                $this->telegram_api->answerCallbackQuery($callback_query_id, 'Pembelian gagal karena kesalahan internal.', true);
             }
         } else {
-            $this->telegram_api->apiRequest('answerCallbackQuery', ['callback_query_id' => $callback_query_id, 'text' => 'Pembelian gagal. Saldo tidak cukup atau item tidak tersedia.', 'show_alert' => true]);
+            $this->telegram_api->answerCallbackQuery($callback_query_id, 'Pembelian gagal. Saldo tidak cukup atau item tidak tersedia.', true);
         }
     }
 }

--- a/webhook.php
+++ b/webhook.php
@@ -132,11 +132,9 @@ try {
         $handler = new MediaHandler($pdo, $update['message'], $user_id_from_telegram, $chat_id_from_telegram, $telegram_message_id);
         $handler->handle();
     } elseif ($update_type === 'callback_query') {
-        app_log("Entering callback_query handler block.", 'bot');
         require_once __DIR__ . '/core/handlers/CallbackQueryHandler.php';
         $handler = new CallbackQueryHandler($pdo, $telegram_api, $current_user, $chat_id_from_telegram, $update['callback_query']);
         $handler->handle();
-        app_log("Exited callback_query handler block.", 'bot');
     } elseif ($update_type === 'message') {
         require_once __DIR__ . '/core/handlers/MessageHandler.php';
         $handler = new MessageHandler($pdo, $telegram_api, $user_repo, $current_user, $chat_id_from_telegram, $message_context);


### PR DESCRIPTION
I've fixed a fatal error: "Call to protected method TelegramAPI::apiRequest() from scope CallbackQueryHandler".

The `CallbackQueryHandler` was incorrectly trying to call the `protected` method `apiRequest` directly. This violates visibility rules, causing the script to fail when you click an inline keyboard button.

To fix this, I made two changes:
1.  I added a new public method, `answerCallbackQuery()`, to the `TelegramAPI` class. This method serves as a proper public interface for answering callback queries, and it calls the protected `apiRequest` method internally.
2.  I updated the `CallbackQueryHandler` to use this new `telegram_api->answerCallbackQuery()` method instead of calling `apiRequest` directly.

These changes resolve the fatal error and ensure that callback queries are handled correctly and securely.