### PR TITLE
feat: Refactor media sending to use copyMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.6.0] - 2025-08-12
+
+### Diubah
+- **Metode Pengiriman Media**: Sistem pengiriman media telah diubah sepenuhnya dari penggunaan `file_id` menjadi metode `copyMessage` dan `copyMessages`.
+  - **Pengiriman Tunggal**: Pratinjau konten yang dikirim melalui perintah `/konten` sekarang menggunakan `copyMessage`.
+  - **Pengiriman Massal**: Pengiriman konten lengkap setelah pembelian atau melalui tombol "Lihat Selengkapnya" sekarang menggunakan `copyMessages` untuk mengirim file sebagai batch.
+- **Keuntungan**: Perubahan ini meningkatkan keandalan pengiriman media, karena `file_id` dapat menjadi tidak valid dari waktu ke waktu, sementara `copyMessage` memastikan media selalu dapat diakses selama ada di channel sumber.
+
 ## [2.5.0] - 2025-08-11
 
 ### Peningkatan

--- a/core/TelegramAPI.php
+++ b/core/TelegramAPI.php
@@ -79,6 +79,48 @@ class TelegramAPI {
     }
 
     /**
+     * Menyalin satu pesan dari satu chat ke chat lain.
+     *
+     * @param int|string $chat_id ID chat tujuan.
+     * @param int|string $from_chat_id ID chat sumber.
+     * @param int $message_id ID pesan yang akan disalin.
+     * @param string|null $caption Caption baru untuk media (opsional).
+     * @param string|null $reply_markup Keyboard inline (opsional).
+     * @return mixed Hasil dari API Telegram.
+     */
+    public function copyMessage($chat_id, $from_chat_id, $message_id, $caption = null, $reply_markup = null) {
+        $data = [
+            'chat_id' => $chat_id,
+            'from_chat_id' => $from_chat_id,
+            'message_id' => $message_id,
+        ];
+        if ($caption !== null) {
+            $data['caption'] = $caption;
+        }
+        if ($reply_markup !== null) {
+            $data['reply_markup'] = $reply_markup;
+        }
+        return $this->apiRequest('copyMessage', $data);
+    }
+
+    /**
+     * Menyalin beberapa pesan dari satu chat ke chat lain.
+     *
+     * @param int|string $chat_id ID chat tujuan.
+     * @param int|string $from_chat_id ID chat sumber.
+     * @param string $message_ids JSON-encoded array dari ID pesan yang akan disalin.
+     * @return mixed Hasil dari API Telegram.
+     */
+    public function copyMessages($chat_id, $from_chat_id, $message_ids) {
+        $data = [
+            'chat_id' => $chat_id,
+            'from_chat_id' => $from_chat_id,
+            'message_ids' => $message_ids,
+        ];
+        return $this->apiRequest('copyMessages', $data);
+    }
+
+    /**
      * Menjawab callback query (misalnya, dari tombol inline).
      *
      * @param string $callback_query_id ID dari callback query.

--- a/core/database/PackageRepository.php
+++ b/core/database/PackageRepository.php
@@ -18,7 +18,7 @@ class PackageRepository
 
     public function getPackageFiles(int $package_id): array
     {
-        $stmt = $this->pdo->prepare("SELECT file_id, type FROM media_files WHERE package_id = ? ORDER BY id");
+        $stmt = $this->pdo->prepare("SELECT file_id, type, chat_id, message_id FROM media_files WHERE package_id = ? ORDER BY id");
         $stmt->execute([$package_id]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }


### PR DESCRIPTION
This commit changes the media sending mechanism from using `file_id` to using the `copyMessage` and `copyMessages` API methods. This improves reliability, as `file_id` can become invalid over time.

The following changes were made:
- Added `copyMessage()` and `copyMessages()` to the `TelegramAPI` class.
- Updated `PackageRepository` to fetch `chat_id` and `message_id`.
- Refactored `MessageHandler` and `CallbackQueryHandler` to use the new methods for sending single and batch media, respectively.
- Updated `CHANGELOG.md` to document the new feature.