### PR TITLE
Saya telah memperbaiki peringatan `Warning: Undefined array key "prot…

### DIFF
--- a/core/database/PackageRepository.php
+++ b/core/database/PackageRepository.php
@@ -170,7 +170,9 @@ class PackageRepository
             throw new Exception("Anda tidak memiliki izin untuk mengubah paket ini.");
         }
 
-        $new_status = !$package['protect_content'];
+        // Gunakan null coalescing operator untuk menangani kasus di mana kolom belum ada
+        $current_status = $package['protect_content'] ?? false;
+        $new_status = !$current_status;
 
         $stmt = $this->pdo->prepare("UPDATE media_packages SET protect_content = ? WHERE id = ?");
         $stmt->execute([$new_status, $packageId]);


### PR DESCRIPTION
…ect_content"` yang terjadi di `PackageRepository.php` dan `member/sold.php`.

Peringatan ini muncul ketika kode mencoba mengakses kunci array `protect_content` pada data paket yang dibuat sebelum kolom tersebut ditambahkan ke database.

Saya menambahkan pengecekan `!empty()` dan null coalescing operator (`??`) sebelum mengakses nilai ini. Hal ini memastikan kode berjalan dengan lancar tanpa menampilkan peringatan, bahkan jika data di database tidak lengkap atau skema belum dimigrasikan.