### PR TITLE
I've completed a major refactoring of the selling workflow and added …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.12.4] - 2025-08-14
+
+### Diperbaiki
+- **Fatal Error di MessageHandler**: Memperbaiki error fatal `Call to a member function hasUserPurchased() on null` yang terjadi saat memproses pesan biasa.
+  - **Penyebab**: `MessageHandler` tidak menginisialisasi `SaleRepository` di dalam constructor-nya, sehingga properti `$this->sale_repo` bernilai `null` saat coba diakses.
+  - **Solusi**: Menambahkan inisialisasi `SaleRepository` di dalam constructor `MessageHandler.php` untuk memastikan semua dependensi tersedia.
+
 ## [3.12.3] - 2025-08-14
 
 ### Diperbaiki

--- a/core/handlers/MessageHandler.php
+++ b/core/handlers/MessageHandler.php
@@ -13,6 +13,7 @@ class MessageHandler
     private $package_repo;
     private $media_repo;
     private $bot_channel_usage_repo;
+    private $sale_repo;
     private $current_user;
     private $chat_id;
     private $message;
@@ -25,6 +26,7 @@ class MessageHandler
         $this->package_repo = new PackageRepository($pdo);
         $this->media_repo = new MediaFileRepository($pdo);
         $this->bot_channel_usage_repo = new BotChannelUsageRepository($pdo);
+        $this->sale_repo = new SaleRepository($pdo);
         $this->current_user = $current_user;
         $this->chat_id = $chat_id;
         $this->message = $message;


### PR DESCRIPTION
…several new features and bug fixes.

**Features & Refactoring:**
- **Refactored `/sell` command:** I've completely overhauled the `/sell` command. It no longer copies media or creates database entries immediately. Instead, it captures the context and waits for a price. All database and file operations are now deferred until the price is confirmed, making cancellations clean and preventing orphaned data or skipped package IDs.
- **New `/addmedia` command:** You can now add more media to a package during creation (to bypass the 10-item limit) or add media to an existing package you own using `/addmedia <ID>`.
- **Edited Caption Sync:** I've implemented a new `EditedMessageHandler` that automatically updates the package description in the database if you edit a media caption.
- **Optimized Album Sales:** I've optimized album sales by using `copyMessages` to copy all items in a media group with a single API call, making the process much more efficient.

**Bug Fixes:**
- **Nested Transaction Error:** I fixed the original critical bug `There is already an active transaction` by removing nested transaction logic from the `PackageRepository`.
- **Fatal Error on `/konten`:** I fixed a fatal error that was caused by a query to the now-deleted `file_id` column.
- **Fatal Error in Admin Logs:** I fixed a fatal error on the admin media logs page, which was also caused by a query to the deleted `file_id` column.
- **Admin Panel Warning:** I fixed a PHP warning on the admin dashboard that was related to a missing array key.
- **`MessageHandler` Initialization:** I fixed a fatal error (`Call to a member function hasUserPurchased() on null`) by ensuring the `SaleRepository` is correctly initialized.

**Database:**
- To optimize the schema, I've removed the redundant `file_id` column from the `media_files` table.