### PR TITLE
fix: Add defensive check for null SaleRepository

### DIFF
--- a/core/handlers/MessageHandler.php
+++ b/core/handlers/MessageHandler.php
@@ -241,6 +241,14 @@ class MessageHandler
 
         $is_admin = ($this->current_user['role'] === 'admin');
         $is_seller = ($package['seller_user_id'] == $internal_user_id);
+
+        // Defensive check: Inexplicably, sale_repo is sometimes null here.
+        // Re-initialize it to prevent a fatal error.
+        if ($this->sale_repo === null) {
+            app_log("DEFENSIVE: Re-initializing SaleRepository in MessageHandler because it was null.", 'warning');
+            $this->sale_repo = new SaleRepository($this->pdo);
+        }
+
         $has_purchased = $this->sale_repo->hasUserPurchased($package_id, $internal_user_id);
 
         $has_access = $is_admin || $is_seller || $has_purchased;


### PR DESCRIPTION
A recurring fatal error `Call to a member function hasUserPurchased() on null` was occurring in `MessageHandler.php`.

Static analysis of the code did not reveal why the `sale_repo` property was null, as it is correctly initialized in the constructor. This suggests a potential runtime issue (e.g., OPcache).

This commit adds a defensive check within the `handleKontenCommand` method. It verifies if `$this->sale_repo` is null and, if so, re-initializes it before use. This prevents the fatal error and adds a warning log to aid in diagnosing the root cause if it persists.