### PR TITLE
fix(db): Remove file_id from getPackageFiles query

### DIFF
--- a/core/database/PackageRepository.php
+++ b/core/database/PackageRepository.php
@@ -18,7 +18,7 @@ class PackageRepository
 
     public function getPackageFiles(int $package_id): array
     {
-        $stmt = $this->pdo->prepare("SELECT file_id, type, chat_id, message_id FROM media_files WHERE package_id = ? ORDER BY id");
+        $stmt = $this->pdo->prepare("SELECT type, chat_id, message_id FROM media_files WHERE package_id = ? ORDER BY id");
         $stmt->execute([$package_id]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }


### PR DESCRIPTION
A previous commit removed the `file_id` column from the `media_files` table but missed updating the `getPackageFiles` method in `PackageRepository.php`.

This resulted in a fatal SQL error: `Column not found: 1054 Unknown column 'file_id' in 'SELECT'`.

This commit corrects the `SELECT` statement in `getPackageFiles` by removing the reference to the non-existent `file_id` column, resolving the fatal error.