### PR TITLE
fix(content): Serve content from storage and ensure correct order

### DIFF
--- a/core/database/PackageRepository.php
+++ b/core/database/PackageRepository.php
@@ -18,7 +18,7 @@ class PackageRepository
 
     public function getPackageFiles(int $package_id): array
     {
-        $stmt = $this->pdo->prepare("SELECT type, chat_id, message_id FROM media_files WHERE package_id = ? ORDER BY id");
+        $stmt = $this->pdo->prepare("SELECT storage_channel_id, storage_message_id FROM media_files WHERE package_id = ? AND storage_message_id IS NOT NULL ORDER BY storage_message_id ASC");
         $stmt->execute([$package_id]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }

--- a/core/handlers/CallbackQueryHandler.php
+++ b/core/handlers/CallbackQueryHandler.php
@@ -60,11 +60,12 @@ class CallbackQueryHandler
 
             $files = $this->package_repo->getPackageFiles($package_id);
             if (!empty($files)) {
-                $from_chat_id = $files[0]['chat_id'];
-                $message_ids = json_encode(array_column($files, 'message_id'));
+                // Gunakan data dari channel penyimpanan, bukan dari sumber asli
+                $from_chat_id = $files[0]['storage_channel_id'];
+                $message_ids = json_encode(array_column($files, 'storage_message_id'));
                 $protect_content = (bool) $package['protect_content'];
 
-                // Kirim media menggunakan copyMessages
+                // Kirim media menggunakan copyMessages dari channel penyimpanan
                 $this->telegram_api->copyMessages(
                     $this->chat_id,
                     $from_chat_id,


### PR DESCRIPTION
This commit addresses two related issues with how content was being sent to you after purchase:

1.  **Incorrect Content Source:** The "View Full" functionality was copying media from its original upload location instead of the secure storage channel. This meant content could become inaccessible if the original message was deleted. The `handleViewFull` method in `CallbackQueryHandler` has been updated to use the `storage_channel_id` and `storage_message_id` for copying.

2.  **Incorrect Content Order:** When viewing a package with multiple media files (especially those added with `/addmedia`), the content was not being sent in the order it was added. The `getPackageFiles` method in `PackageRepository` has been updated to `ORDER BY storage_message_id ASC`, which reflects the chronological order in which media was added to the package.

These changes ensure that purchased content is served reliably from the secure storage channel and is always presented to you in the correct, chronological order.