### PR TITLE
feat: Implement paginated content viewing

### DIFF
--- a/core/handlers/MessageHandler.php
+++ b/core/handlers/MessageHandler.php
@@ -255,7 +255,8 @@ class MessageHandler
 
         $keyboard = [];
         if ($has_access) {
-            $keyboard = ['inline_keyboard' => [[['text' => 'Lihat Selengkapnya 📂', 'callback_data' => "view_full_{$package['public_id']}"]]]];
+            // Mengarahkan ke handler pagination halaman pertama (indeks 0)
+            $keyboard = ['inline_keyboard' => [[['text' => 'Lihat Selengkapnya 📂', 'callback_data' => "view_page_{$package['public_id']}_0"]]]];
         } elseif ($package['status'] === 'available') {
             $price_formatted = "Rp " . number_format($package['price'], 0, ',', '.');
             $keyboard = ['inline_keyboard' => [[['text' => "Beli Konten Ini ({$price_formatted}) 🛒", 'callback_data' => "buy_{$package['public_id']}"]]]];


### PR DESCRIPTION
This commit replaces the "View Full" functionality with a new paginated viewing experience for purchased content.

Previously, all media files in a package were sent at once. Now, content is presented in "pages," where each page is either a single media item or a full album/media group.

Changes include:
- A new `getGroupedPackageContent` method in `PackageRepository` to fetch and group package content into chronologically ordered pages.
- The `/konten` command in `MessageHandler` now generates a callback to the first page of the new pagination view.
- A new `handleViewPage` method in `CallbackQueryHandler` manages the pagination logic, sending the content for the current page and providing a dynamic inline keyboard with "Previous" and "Next" buttons for navigation.
- The purchase flow in `handleBuy` now also directs users to the new paginated view.

This new system provides a much better user experience, especially for large packages with many media items or albums.