### PR TITLE
Fitur: Posting Manual Konten ke Channel Jualan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [4.2.0] - 2025-08-15
+
+### Fitur
+- **Posting Konten ke Channel Jualan**: Penjual sekarang dapat mendaftarkan channel jualan mereka dan mem-posting konten ke sana.
+  - **Pendaftaran Channel**: Perintah baru `/register_channel <ID Channel>` memungkinkan penjual untuk mendaftarkan channel mereka melalui chat pribadi dengan bot. Bot akan memverifikasi bahwa ia adalah admin di channel tersebut.
+  - **Tombol Posting Manual**: Saat melihat detail konten milik sendiri via `/konten`, penjual akan melihat tombol baru "Post ke Channel".
+  - **Penanganan Kegagalan Otomatis**: Jika bot gagal mem-posting ke channel (misalnya, karena sudah bukan admin), channel tersebut akan otomatis di-unregister dari sistem untuk mencegah error berulang.
+
 ## [4.1.0] - 2025-08-14
 
 ### Fitur

--- a/core/TelegramAPI.php
+++ b/core/TelegramAPI.php
@@ -381,6 +381,30 @@ class TelegramAPI {
     }
 
     /**
+     * Mendapatkan ID numerik dari bot saat ini.
+     * @return int|null ID bot atau null jika gagal.
+     */
+    public function getBotId()
+    {
+        $response = $this->getMe();
+        return $response['ok'] ? $response['result']['id'] : null;
+    }
+
+    /**
+     * Mendapatkan informasi tentang sebuah chat (channel, grup, atau user).
+     *
+     * @param int|string $chat_id ID atau username dari chat.
+     * @return mixed Hasil dari API Telegram.
+     */
+    public function getChat($chat_id)
+    {
+        $data = [
+            'chat_id' => $chat_id,
+        ];
+        return $this->apiRequest('getChat', $data);
+    }
+
+    /**
      * Menjawab inline query.
      *
      * @param string $inline_query_id ID dari inline query.

--- a/core/database/PackageRepository.php
+++ b/core/database/PackageRepository.php
@@ -285,4 +285,31 @@ class PackageRepository
             throw new Exception("Gagal membuat paket baru: " . $e->getMessage());
         }
     }
+
+    /**
+     * Mendapatkan file media yang dijadikan thumbnail untuk sebuah paket.
+     *
+     * @param int $package_id ID paket.
+     * @return array|false Data file thumbnail atau false jika tidak ditemukan.
+     */
+    public function getThumbnailFile(int $package_id)
+    {
+        $package = $this->find($package_id);
+        if (!$package) return false;
+
+        $thumbnail_media_id = $package['thumbnail_media_id'];
+
+        // Jika thumbnail spesifik di-set, gunakan itu
+        if (!empty($thumbnail_media_id)) {
+            $stmt = $this->pdo->prepare("SELECT * FROM media_files WHERE id = ?");
+            $stmt->execute([$thumbnail_media_id]);
+            $thumb = $stmt->fetch(PDO::FETCH_ASSOC);
+            if ($thumb) return $thumb;
+        }
+
+        // Jika tidak, gunakan file pertama yang terkait dengan paket
+        $stmt = $this->pdo->prepare("SELECT * FROM media_files WHERE package_id = ? ORDER BY id ASC LIMIT 1");
+        $stmt->execute([$package_id]);
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
 }


### PR DESCRIPTION
Menambahkan fungsionalitas bagi penjual untuk mendaftarkan channel jualan dan mem-posting konten mereka ke sana secara manual.

- **Pendaftaran Channel**: Penjual dapat menggunakan perintah `/register_channel <ID>` di chat pribadi untuk mendaftarkan channel mereka. Bot akan memverifikasi status admin sebelum menyimpan.
- **Tombol Posting**: Saat melihat konten mereka sendiri via `/konten`, penjual kini akan melihat tombol "Post ke Channel".
- **Callback & Penanganan Kegagalan**: Menekan tombol tersebut akan memicu bot untuk mem-posting pratinjau konten ke channel terdaftar. Jika gagal (misal, bot bukan admin lagi), channel akan otomatis di-unregister untuk mencegah error di masa depan.
- **Infrastruktur**: Menambahkan tabel `seller_sales_channels` dan `SellerSalesChannelRepository` untuk mengelola data.