### PR TITLE
Perbaiki TypeError pada Perintah /start dengan Deep Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.2.2] - 2025-08-15
+
+### Diperbaiki
+- **Fatal Error pada Perintah /start dengan Deep Link**: Memperbaiki error `TypeError` yang terjadi saat pengguna menggunakan tautan `start` yang berisi ID paket (misalnya, dari tombol "Beli").
+  - **Penyebab**: ID paket diekstrak sebagai string, tetapi metode `PackageRepository::find()` mengharapkan integer.
+  - **Solusi**: Melakukan konversi tipe data (casting) ID paket menjadi integer sebelum memanggil metode `find()`.
+
 ## [4.2.1] - 2025-08-15
 
 ### Diperbaiki

--- a/core/handlers/MessageHandler.php
+++ b/core/handlers/MessageHandler.php
@@ -262,7 +262,7 @@ EOT;
     {
         if (count($parts) > 1 && strpos($parts[1], 'package_') === 0) {
             $package_id = substr($parts[1], strlen('package_'));
-            $package = $this->package_repo->find($package_id);
+            $package = $this->package_repo->find((int)$package_id);
             if ($package && $package['status'] == 'available') {
                 $price_formatted = "Rp " . number_format($package['price'], 0, ',', '.');
                 $balance_formatted = "Rp " . number_format($this->current_user['balance'], 0, ',', '.');


### PR DESCRIPTION
Memperbaiki error fatal `TypeError: PackageRepository::find(): Argument #1 ($id) must be of type int, string given` yang terjadi saat pengguna mengklik tombol "Beli" atau menggunakan tautan `start` dengan ID paket.

- **Penyebab**: ID paket diekstrak dari parameter `start` sebagai string, tetapi metode `PackageRepository::find()` memiliki type hint yang ketat untuk integer.
- **Solusi**: Melakukan type casting `(int)` pada variabel ID paket sebelum memanggil metode `find()` di dalam `MessageHandler.php`.