### PR TITLE
Perbaiki Error SQL 'Unknown column' di Halaman Konten Dijual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.2.3] - 2025-08-15
+
+### Diperbaiki
+- **Fatal Error di Halaman "Konten Dijual"**: Memperbaiki error `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'mf.file_id'` yang terjadi saat member membuka halaman "Konten Dijual".
+  - **Penyebab**: Query database untuk mengambil daftar konten yang dijual (`findAllBySellerId`) masih mencoba memilih kolom `file_id` yang sudah dihapus.
+  - **Solusi**: Menghapus referensi ke kolom `mf.file_id` dari query di `PackageRepository.php`.
+
 ## [4.2.2] - 2025-08-15
 
 ### Diperbaiki

--- a/core/database/PackageRepository.php
+++ b/core/database/PackageRepository.php
@@ -98,9 +98,8 @@ class PackageRepository
     public function findAllBySellerId(int $sellerId): array
     {
         $stmt = $this->pdo->prepare(
-            "SELECT mp.*, mf.file_id as thumbnail_file_id
+            "SELECT mp.*
              FROM media_packages mp
-             LEFT JOIN media_files mf ON mp.thumbnail_media_id = mf.id
              WHERE mp.seller_user_id = ? AND mp.status != 'deleted'
              ORDER BY mp.created_at DESC"
         );


### PR DESCRIPTION
Memperbaiki error fatal `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'mf.file_id'` yang terjadi saat member membuka halaman "Konten Dijual" di panel member.

- **Penyebab**: Metode `findAllBySellerId` di `PackageRepository.php` masih mencoba memilih kolom `file_id` dari tabel `media_files`, padahal kolom tersebut sudah dihapus dari skema database.
- **Solusi**: Memperbarui query SQL di dalam metode tersebut untuk menghapus referensi ke kolom `mf.file_id` dan join yang tidak diperlukan.