### PR TITLE
Perbaiki Error SQL 'Unknown column' di Halaman Konten Dibeli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.2.4] - 2025-08-15
+
+### Diperbaiki
+- **Fatal Error di Halaman "Konten Dibeli"**: Memperbaiki error `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'mf.file_id'` yang terjadi saat member membuka halaman "Konten Dibeli".
+  - **Penyebab**: Query database untuk mengambil daftar konten yang dibeli (`findPackagesByBuyerId`) masih mencoba memilih kolom `file_id` yang sudah dihapus.
+  - **Solusi**: Menghapus referensi ke kolom `mf.file_id` dari query di `SaleRepository.php`.
+
 ## [4.2.3] - 2025-08-15
 
 ### Diperbaiki

--- a/core/database/SaleRepository.php
+++ b/core/database/SaleRepository.php
@@ -68,10 +68,9 @@ class SaleRepository
     public function findPackagesByBuyerId(int $buyerId): array
     {
         $stmt = $this->pdo->prepare(
-            "SELECT s.purchased_at, mp.*, mf.file_id as thumbnail_file_id
+            "SELECT s.purchased_at, mp.*
              FROM sales s
              JOIN media_packages mp ON s.package_id = mp.id
-             LEFT JOIN media_files mf ON mp.thumbnail_media_id = mf.id
              WHERE s.buyer_user_id = ?
              ORDER BY s.purchased_at DESC"
         );


### PR DESCRIPTION
Memperbaiki error fatal `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'mf.file_id'` yang terjadi saat member membuka halaman "Konten Dibeli" di panel member.

- **Penyebab**: Metode `findPackagesByBuyerId` di `SaleRepository.php` masih mencoba memilih kolom `file_id` dari tabel `media_files`, padahal kolom tersebut sudah dihapus dari skema database.
- **Solusi**: Memperbarui query SQL di dalam metode tersebut untuk menghapus referensi ke kolom `mf.file_id` dan join yang tidak diperlukan.