### PR TITLE
Perbaiki Format Markdown pada Perintah /help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.2.5] - 2025-08-15
+
+### Diperbaiki
+- **Format Markdown Rusak pada Perintah /help**: Memperbaiki masalah format pada pesan `/help` yang menyebabkan teks tidak ditampilkan dengan benar.
+  - **Penyebab**: Karakter garis bawah (`_`) dalam contoh ID paket (misalnya, `ABCD_0001`) tidak di-escape, sehingga merusak parser Markdown Telegram.
+  - **Solusi**: Melakukan escaping pada karakter `_` di semua contoh ID dalam teks bantuan.
+
 ## [4.2.4] - 2025-08-15
 
 ### Diperbaiki

--- a/core/handlers/MessageHandler.php
+++ b/core/handlers/MessageHandler.php
@@ -196,7 +196,7 @@ Ini adalah cara menjual yang paling umum.
 - **Langkah 1:** Kirim media (foto, video, atau album/media group) ke chat bot.
 - **Langkah 2:** **Reply** (balas) media yang baru saja Anda kirim dengan perintah `/sell`.
 - **Langkah 3:** Bot akan meminta Anda untuk memasukkan harga. Kirim harga dalam bentuk angka (contoh: `50000`).
-- **Selesai!** 🎉 Paket Anda sekarang tersedia untuk dijual dengan ID unik (contoh: `ABCD_0001`).
+- **Selesai!** 🎉 Paket Anda sekarang tersedia untuk dijual dengan ID unik (contoh: `ABCD\_0001`).
 
 **Catatan Penting:**
 - **Deskripsi:** 📝 Caption (teks) dari media yang Anda reply akan secara otomatis digunakan sebagai deskripsi produk. Jika Anda menjual album, bot akan secara cerdas mencari caption dari salah satu item di dalam album tersebut.
@@ -216,14 +216,14 @@ Telegram memiliki batas 10 item per media group. Untuk menjual paket yang lebih 
 Anda dapat menambahkan media baru ke paket yang sudah Anda jual.
 
 - **Langkah 1:** Kirim media atau album baru yang ingin Anda tambahkan.
-- **Langkah 2:** Reply media/album baru tersebut dengan perintah `/addmedia <ID_PAKET>`, di mana `<ID_PAKET>` adalah ID dari paket yang ingin Anda edit (contoh: `/addmedia ABCD_0001`).
+- **Langkah 2:** Reply media/album baru tersebut dengan perintah `/addmedia <ID_PAKET>`, di mana `<ID_PAKET>` adalah ID dari paket yang ingin Anda edit (contoh: `/addmedia ABCD\_0001`).
 - **Selesai!** ✅ Media baru akan ditambahkan ke paket yang sudah ada.
 
 ## 4. 📂 Melihat Konten
 
 Baik sebagai penjual maupun pembeli, Anda dapat melihat konten yang Anda miliki.
 
-- **Langkah 1:** Gunakan perintah `/konten <ID_PAKET>` (contoh: `/konten ABCD_0001`).
+- **Langkah 1:** Gunakan perintah `/konten <ID_PAKET>` (contoh: `/konten ABCD\_0001`).
 - **Langkah 2:** Bot akan menampilkan pratinjau konten. Jika Anda memiliki akses (sebagai penjual atau pembeli), Anda akan melihat tombol **"Lihat Selengkapnya 📂"**.
 - **Langkah 3:** Tekan tombol tersebut untuk masuk ke mode penampil konten.
 


### PR DESCRIPTION
Memperbaiki masalah rendering pada pesan `/help` yang disebabkan oleh karakter yang tidak di-escape dengan benar.

- **Penyebab**: Karakter garis bawah (`_`) dalam contoh ID paket (misal: `ABCD_0001`) ditafsirkan sebagai penanda format oleh parser Markdown Telegram, yang merusak tampilan teks.
- **Solusi**: Melakukan escaping pada karakter `_` (menjadi `\_`) di semua contoh ID dalam teks bantuan di `MessageHandler.php` untuk memastikan teks ditampilkan seperti yang diharapkan.