### PR TITLE
Perbaiki: Atasi Telegram API error "can't parse entities"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 
+## [4.2.8] - 2025-08-16
+
+### Diperbaiki
+- **Fatal Error `can't parse entities` pada Berbagai Perintah**: Memperbaiki error `can't parse entities` yang disebabkan oleh karakter khusus (`=`, `!`, `.`, `(`, `)`, dll.) dalam data dinamis (seperti nama pengguna, deskripsi item) atau teks statis di berbagai perintah.
+  - **Penyebab**: Pesan yang dikirim dengan `parse_mode=Markdown` atau `MarkdownV2` tidak melakukan escaping pada karakter-karakter khusus yang dicadangkan oleh Telegram, menyebabkan API gagal mem-parsing pesan.
+  - **Solusi**:
+    1.  Membuat fungsi helper baru `escapeMarkdownV2()` di `TelegramAPI.php` untuk melakukan escaping pada semua karakter khusus sesuai standar `MarkdownV2`.
+    2.  Mengubah semua `parse_mode` yang relevan di `MessageHandler.php` dan `webhook.php` menjadi `MarkdownV2`.
+    3.  Menerapkan fungsi `escapeMarkdownV2()` pada semua data dinamis yang dimasukkan ke dalam pesan.
+    4.  Melakukan escaping manual pada karakter khusus di semua teks pesan statis untuk memastikan konsistensi.
+
 ## [4.2.7] - 2025-08-15
 
 ### Diperbaiki

--- a/core/TelegramAPI.php
+++ b/core/TelegramAPI.php
@@ -156,6 +156,18 @@ class TelegramAPI {
     }
 
     /**
+     * Escapes text for use in MarkdownV2 parse mode.
+     * @param string $text The text to escape.
+     * @return string The escaped text.
+     */
+    public function escapeMarkdownV2($text)
+    {
+        // Characters to escape for MarkdownV2
+        $escape_chars = '_*[]()~`>#+-=|{}.!';
+        return preg_replace('/([' . preg_quote($escape_chars, '/') . '])/', '\\\\$1', $text);
+    }
+
+    /**
      * Mengirim pesan teks ke sebuah chat.
      *
      * @param int|string $chat_id ID dari chat tujuan.

--- a/webhook.php
+++ b/webhook.php
@@ -129,7 +129,7 @@ try {
         $state_context = json_decode($current_user['state_context'] ?? '{}', true);
         if (strpos($text, '/cancel') === 0) {
             $user_repo->setUserState($internal_user_id, null, null);
-            $telegram_api->sendMessage($chat_id_from_telegram, "Operasi dibatalkan.");
+            $telegram_api->sendMessage($chat_id_from_telegram, "Operasi dibatalkan\\.", 'MarkdownV2');
             $update_handled = true;
         } else {
             // ... (logika state-based lainnya seperti 'awaiting_price')
@@ -193,7 +193,7 @@ try {
 
                 $copied_messages_result = $telegram_api->copyMessages($storage_channel_id, $from_chat_id, json_encode($original_message_ids));
                 if (!$copied_messages_result || !isset($copied_messages_result['ok']) || !$copied_messages_result['ok'] || count($copied_messages_result['result']) !== count($original_message_ids)) {
-                    $telegram_api->sendMessage($chat_id_from_telegram, "⚠️ Gagal menyimpan semua media. Proses dibatalkan.");
+                    $telegram_api->sendMessage($chat_id_from_telegram, "⚠️ Gagal menyimpan semua media\\. Proses dibatalkan\\.", 'MarkdownV2');
                     // ... error handling ...
                     exit;
                 }
@@ -214,12 +214,13 @@ try {
                 $user_repo->setUserState($internal_user_id, null, null);
                 $package = $package_repo->find($package_id);
                 $public_id_display = $package['public_id'] ?? 'N/A';
-                $telegram_api->sendMessage($chat_id_from_telegram, "✅ Harga telah ditetapkan. Paket media Anda dengan ID *{$public_id_display}* sekarang tersedia untuk dijual.");
+                $escaped_public_id = $telegram_api->escapeMarkdownV2($public_id_display);
+                $telegram_api->sendMessage($chat_id_from_telegram, "✅ Harga telah ditetapkan\\. Paket media Anda dengan ID *{$escaped_public_id}* sekarang tersedia untuk dijual\\.", 'MarkdownV2');
 
                 $update_handled = true;
 
             } elseif ($current_user['state'] == 'awaiting_price') {
-                 $telegram_api->sendMessage($chat_id_from_telegram, "⚠️ Harga tidak valid. Harap masukkan angka saja (contoh: 50000).");
+                 $telegram_api->sendMessage($chat_id_from_telegram, "⚠️ Harga tidak valid\\. Harap masukkan angka saja \\(contoh: 50000\\)\\.", 'MarkdownV2');
                  $update_handled = true;
             }
         }


### PR DESCRIPTION
Memperbaiki error fatal `can't parse entities` dari API Telegram yang terjadi ketika mengirim pesan yang mengandung karakter khusus (seperti `=`, `!`, `.`, `(`, `)`) tanpa di-escape dengan benar saat menggunakan `parse_mode` Markdown.

- Menambahkan fungsi helper `escapeMarkdownV2()` di `TelegramAPI.php`.
- Mengubah `parse_mode` menjadi `MarkdownV2` di `MessageHandler.php` dan `webhook.php`.
- Menerapkan escaping pada semua data dinamis dan teks statis di pesan yang relevan.
- Memperbarui `CHANGELOG.md`.