### PR TITLE
Perbaiki: Atasi secara menyeluruh error "can't parse entities"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 
+## [4.2.9] - 2025-08-16
+
+### Diperbaiki
+- **Fatal Error `can't parse entities` pada Callback Handler**: Memperbaiki error `can't parse entities` yang terlewat pada beberapa alur kerja yang ditangani oleh `CallbackQueryHandler`.
+  - **Penyebab**: Beberapa metode di `CallbackQueryHandler` (seperti `handleRegisterSeller` dan `handlePostToChannel`) masih mengirim pesan dengan `parse_mode` `Markdown` atau tidak menyertakan `parse_mode` saat mengirim caption dengan markup, serta tidak melakukan escaping pada konten. Selain itu, metode `copyMessage` di `TelegramAPI.php` tidak mendukung parameter `parse_mode`.
+  - **Solusi**:
+    1.  Menambahkan dukungan parameter `parse_mode` ke metode `copyMessage` di `TelegramAPI.php`.
+    2.  Di `CallbackQueryHandler.php`, mengubah semua pemanggilan `sendMessage` dan `copyMessage` yang relevan untuk menggunakan `parse_mode=MarkdownV2`.
+    3.  Menerapkan fungsi `escapeMarkdownV2()` pada semua konten dinamis (seperti ID publik, deskripsi, harga) sebelum dikirim.
+
 ## [4.2.8] - 2025-08-16
 
 ### Diperbaiki

--- a/core/TelegramAPI.php
+++ b/core/TelegramAPI.php
@@ -216,7 +216,7 @@ class TelegramAPI {
      * @param bool $protect_content Melindungi konten dari forward dan save.
      * @return mixed Hasil dari API Telegram.
      */
-    public function copyMessage($chat_id, $from_chat_id, $message_id, $caption = null, $reply_markup = null, bool $protect_content = false) {
+    public function copyMessage($chat_id, $from_chat_id, $message_id, $caption = null, $parse_mode = null, $reply_markup = null, bool $protect_content = false) {
         $data = [
             'chat_id' => $chat_id,
             'from_chat_id' => $from_chat_id,
@@ -224,6 +224,9 @@ class TelegramAPI {
         ];
         if ($caption !== null) {
             $data['caption'] = $caption;
+        }
+        if ($parse_mode) {
+            $data['parse_mode'] = $parse_mode;
         }
         if ($reply_markup !== null) {
             $data['reply_markup'] = $reply_markup;

--- a/core/handlers/CallbackQueryHandler.php
+++ b/core/handlers/CallbackQueryHandler.php
@@ -78,9 +78,13 @@ class CallbackQueryHandler
         // 4. Format the message and keyboard
         $price_formatted = "Rp " . number_format($package['price'], 0, ',', '.');
         $buy_url = "https://t.me/" . BOT_USERNAME . "?start=package_" . $package['public_id'];
+
+        $escaped_description = $this->telegram_api->escapeMarkdownV2($package['description']);
+        $escaped_price = $this->telegram_api->escapeMarkdownV2($price_formatted);
+
         $caption = "✨ *Konten Baru Tersedia* ✨\n\n" .
-                   "{$package['description']}\n\n" .
-                   "Harga: *{$price_formatted}*";
+                   "{$escaped_description}\n\n" .
+                   "Harga: *{$escaped_price}*";
         $keyboard = ['inline_keyboard' => [[['text' => "Beli Sekarang 🛒", 'url' => $buy_url]]]];
         $reply_markup = json_encode($keyboard);
 
@@ -91,6 +95,7 @@ class CallbackQueryHandler
                 $thumbnail['chat_id'],
                 $thumbnail['message_id'],
                 $caption,
+                'MarkdownV2',
                 $reply_markup,
                 (bool)$package['protect_content']
             );
@@ -210,8 +215,9 @@ class CallbackQueryHandler
 
         try {
             $public_id = $this->user_repo->setPublicId($user_id);
-            $message = "Selamat! Anda berhasil terdaftar sebagai penjual.\n\nID Penjual Publik Anda adalah: *{$public_id}*\n\nSekarang Anda dapat menggunakan perintah /sell dengan me-reply media yang ingin Anda jual.";
-            $this->telegram_api->sendMessage($this->chat_id, $message, 'Markdown');
+            $escaped_public_id = $this->telegram_api->escapeMarkdownV2($public_id);
+            $message = "Selamat\\! Anda berhasil terdaftar sebagai penjual\\.\n\nID Penjual Publik Anda adalah: *{$escaped_public_id}*\n\nSekarang Anda dapat menggunakan perintah /sell dengan me\\-reply media yang ingin Anda jual\\.";
+            $this->telegram_api->sendMessage($this->chat_id, $message, 'MarkdownV2');
             $this->telegram_api->answerCallbackQuery($callback_query_id);
         } catch (Exception $e) {
             $this->telegram_api->answerCallbackQuery($callback_query_id, 'Terjadi kesalahan saat mendaftar. Coba lagi.', true);

--- a/core/handlers/ChannelPostHandler.php
+++ b/core/handlers/ChannelPostHandler.php
@@ -91,9 +91,10 @@ class ChannelPostHandler
 
         if ($success) {
             $channel_title = $this->message['chat']['title'] ?? 'channel ini';
-            $this->telegram_api->sendMessage($this->channel_id, "✅ Channel *{$channel_title}* berhasil didaftarkan sebagai channel jualan Anda.");
+            $escaped_title = $this->telegram_api->escapeMarkdownV2($channel_title);
+            $this->telegram_api->sendMessage($this->channel_id, "✅ Channel *{$escaped_title}* berhasil didaftarkan sebagai channel jualan Anda\\.", 'MarkdownV2');
         } else {
-            $this->telegram_api->sendMessage($this->channel_id, "⚠️ Terjadi kesalahan database.");
+            $this->telegram_api->sendMessage($this->channel_id, "⚠️ Terjadi kesalahan database\\.", 'MarkdownV2');
         }
         */
     }


### PR DESCRIPTION
Memperbaiki secara tuntas error `can't parse entities` dengan menambahkan dukungan `parse_mode` ke `copyMessage` dan memperbaiki semua pemanggilan `sendMessage` dan `copyMessage` di `CallbackQueryHandler` dan `ChannelPostHandler` untuk menggunakan `MarkdownV2` dan escaping yang benar.