### PR TITLE
Refactor: Ganti parse_mode ke Markdown legacy sesuai permintaan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 
+## [4.2.10] - 2025-08-16
+
+### Diubah
+- **Mengembalikan ke Mode `Markdown` Legacy**: Sesuai permintaan pengguna, semua penggunaan `parse_mode` diubah kembali dari `MarkdownV2` ke mode `Markdown` legacy.
+  - **Penyebab**: Pengguna meminta untuk menggunakan mode parsing Markdown yang biasa, bukan `MarkdownV2`.
+  - **Solusi**:
+    1.  Mengganti nama fungsi `escapeMarkdownV2` menjadi `escapeMarkdown` di `TelegramAPI.php` dan menyesuaikan logikanya untuk hanya melakukan escape pada karakter `_`, `*`, `\``, dan `[`.
+    2.  Mengubah semua `parse_mode` dari `'MarkdownV2'` menjadi `'Markdown'` di semua file handler (`MessageHandler`, `CallbackQueryHandler`, `ChannelPostHandler`) dan `webhook.php`.
+    3.  Menghapus escaping manual untuk karakter yang tidak relevan dengan mode `Markdown` legacy (seperti `.`, `!`, `(`, `)`).
+
 ## [4.2.9] - 2025-08-16
 
 ### Diperbaiki

--- a/core/TelegramAPI.php
+++ b/core/TelegramAPI.php
@@ -156,14 +156,14 @@ class TelegramAPI {
     }
 
     /**
-     * Escapes text for use in MarkdownV2 parse mode.
+     * Escapes text for use in legacy Markdown parse mode.
      * @param string $text The text to escape.
      * @return string The escaped text.
      */
-    public function escapeMarkdownV2($text)
+    public function escapeMarkdown($text)
     {
-        // Characters to escape for MarkdownV2
-        $escape_chars = '_*[]()~`>#+-=|{}.!';
+        // Characters to escape for legacy Markdown
+        $escape_chars = '_*`[';
         return preg_replace('/([' . preg_quote($escape_chars, '/') . '])/', '\\\\$1', $text);
     }
 

--- a/core/handlers/CallbackQueryHandler.php
+++ b/core/handlers/CallbackQueryHandler.php
@@ -79,8 +79,8 @@ class CallbackQueryHandler
         $price_formatted = "Rp " . number_format($package['price'], 0, ',', '.');
         $buy_url = "https://t.me/" . BOT_USERNAME . "?start=package_" . $package['public_id'];
 
-        $escaped_description = $this->telegram_api->escapeMarkdownV2($package['description']);
-        $escaped_price = $this->telegram_api->escapeMarkdownV2($price_formatted);
+        $escaped_description = $this->telegram_api->escapeMarkdown($package['description']);
+        $escaped_price = $this->telegram_api->escapeMarkdown($price_formatted);
 
         $caption = "✨ *Konten Baru Tersedia* ✨\n\n" .
                    "{$escaped_description}\n\n" .
@@ -95,7 +95,7 @@ class CallbackQueryHandler
                 $thumbnail['chat_id'],
                 $thumbnail['message_id'],
                 $caption,
-                'MarkdownV2',
+                'Markdown',
                 $reply_markup,
                 (bool)$package['protect_content']
             );
@@ -215,9 +215,9 @@ class CallbackQueryHandler
 
         try {
             $public_id = $this->user_repo->setPublicId($user_id);
-            $escaped_public_id = $this->telegram_api->escapeMarkdownV2($public_id);
-            $message = "Selamat\\! Anda berhasil terdaftar sebagai penjual\\.\n\nID Penjual Publik Anda adalah: *{$escaped_public_id}*\n\nSekarang Anda dapat menggunakan perintah /sell dengan me\\-reply media yang ingin Anda jual\\.";
-            $this->telegram_api->sendMessage($this->chat_id, $message, 'MarkdownV2');
+            $escaped_public_id = $this->telegram_api->escapeMarkdown($public_id);
+            $message = "Selamat! Anda berhasil terdaftar sebagai penjual.\n\nID Penjual Publik Anda adalah: *{$escaped_public_id}*\n\nSekarang Anda dapat menggunakan perintah /sell dengan me-reply media yang ingin Anda jual.";
+            $this->telegram_api->sendMessage($this->chat_id, $message, 'Markdown');
             $this->telegram_api->answerCallbackQuery($callback_query_id);
         } catch (Exception $e) {
             $this->telegram_api->answerCallbackQuery($callback_query_id, 'Terjadi kesalahan saat mendaftar. Coba lagi.', true);

--- a/core/handlers/ChannelPostHandler.php
+++ b/core/handlers/ChannelPostHandler.php
@@ -91,10 +91,10 @@ class ChannelPostHandler
 
         if ($success) {
             $channel_title = $this->message['chat']['title'] ?? 'channel ini';
-            $escaped_title = $this->telegram_api->escapeMarkdownV2($channel_title);
-            $this->telegram_api->sendMessage($this->channel_id, "✅ Channel *{$escaped_title}* berhasil didaftarkan sebagai channel jualan Anda\\.", 'MarkdownV2');
+            $escaped_title = $this->telegram_api->escapeMarkdown($channel_title);
+            $this->telegram_api->sendMessage($this->channel_id, "✅ Channel *{$escaped_title}* berhasil didaftarkan sebagai channel jualan Anda.", 'Markdown');
         } else {
-            $this->telegram_api->sendMessage($this->channel_id, "⚠️ Terjadi kesalahan database\\.", 'MarkdownV2');
+            $this->telegram_api->sendMessage($this->channel_id, "⚠️ Terjadi kesalahan database.");
         }
         */
     }

--- a/webhook.php
+++ b/webhook.php
@@ -129,7 +129,7 @@ try {
         $state_context = json_decode($current_user['state_context'] ?? '{}', true);
         if (strpos($text, '/cancel') === 0) {
             $user_repo->setUserState($internal_user_id, null, null);
-            $telegram_api->sendMessage($chat_id_from_telegram, "Operasi dibatalkan\\.", 'MarkdownV2');
+            $telegram_api->sendMessage($chat_id_from_telegram, "Operasi dibatalkan.");
             $update_handled = true;
         } else {
             // ... (logika state-based lainnya seperti 'awaiting_price')
@@ -193,7 +193,7 @@ try {
 
                 $copied_messages_result = $telegram_api->copyMessages($storage_channel_id, $from_chat_id, json_encode($original_message_ids));
                 if (!$copied_messages_result || !isset($copied_messages_result['ok']) || !$copied_messages_result['ok'] || count($copied_messages_result['result']) !== count($original_message_ids)) {
-                    $telegram_api->sendMessage($chat_id_from_telegram, "⚠️ Gagal menyimpan semua media\\. Proses dibatalkan\\.", 'MarkdownV2');
+                    $telegram_api->sendMessage($chat_id_from_telegram, "⚠️ Gagal menyimpan semua media. Proses dibatalkan.");
                     // ... error handling ...
                     exit;
                 }
@@ -214,13 +214,13 @@ try {
                 $user_repo->setUserState($internal_user_id, null, null);
                 $package = $package_repo->find($package_id);
                 $public_id_display = $package['public_id'] ?? 'N/A';
-                $escaped_public_id = $telegram_api->escapeMarkdownV2($public_id_display);
-                $telegram_api->sendMessage($chat_id_from_telegram, "✅ Harga telah ditetapkan\\. Paket media Anda dengan ID *{$escaped_public_id}* sekarang tersedia untuk dijual\\.", 'MarkdownV2');
+                $escaped_public_id = $telegram_api->escapeMarkdown($public_id_display);
+                $telegram_api->sendMessage($chat_id_from_telegram, "✅ Harga telah ditetapkan. Paket media Anda dengan ID *{$escaped_public_id}* sekarang tersedia untuk dijual.", 'Markdown');
 
                 $update_handled = true;
 
             } elseif ($current_user['state'] == 'awaiting_price') {
-                 $telegram_api->sendMessage($chat_id_from_telegram, "⚠️ Harga tidak valid\\. Harap masukkan angka saja \\(contoh: 50000\\)\\.", 'MarkdownV2');
+                 $telegram_api->sendMessage($chat_id_from_telegram, "⚠️ Harga tidak valid. Harap masukkan angka saja (contoh: 50000).");
                  $update_handled = true;
             }
         }


### PR DESCRIPTION
Mengubah implementasi dari `MarkdownV2` kembali ke `Markdown` legacy di seluruh aplikasi.

- Mengubah fungsi `escapeMarkdownV2` menjadi `escapeMarkdown` dengan logika yang lebih sederhana.
- Mengganti `parse_mode` di semua file handler dan webhook.
- Menghapus escaping manual yang tidak lagi diperlukan.
- Memperbarui `CHANGELOG.md`.