### PR TITLE
Fix: Correct copyMessage argument order for parse_mode

### DIFF
--- a/core/handlers/CallbackQueryHandler.php
+++ b/core/handlers/CallbackQueryHandler.php
@@ -184,6 +184,7 @@ class CallbackQueryHandler
                 $from_chat_id,
                 $current_page_content[0]['storage_message_id'],
                 null, // caption
+                null, // parse_mode
                 $reply_markup,
                 $protect_content
             );

--- a/core/handlers/MessageHandler.php
+++ b/core/handlers/MessageHandler.php
@@ -430,6 +430,7 @@ EOT;
                 $thumbnail['chat_id'],
                 $thumbnail['message_id'],
                 $caption,
+                null, // parse_mode
                 $reply_markup
             );
         } else {


### PR DESCRIPTION
The Telegram API was returning a '400 Bad Request: unsupported parse_mode' error because the `copyMessage` method was being called with arguments in the wrong order.

The `reply_markup` argument was being passed in the position of the `parse_mode` argument. This commit corrects the argument order in the two places where the call was incorrect: `MessageHandler.php` and `CallbackQueryHandler.php`.

A `null` value is now explicitly passed for the `parse_mode` parameter in these calls, which resolves the error.