### PR TITLE
Feat: Send channel post actions to discussion thread

### DIFF
--- a/core/TelegramAPI.php
+++ b/core/TelegramAPI.php
@@ -176,7 +176,7 @@ class TelegramAPI {
      * @param string|null $reply_markup Keyboard inline atau kustom dalam format JSON.
      * @return mixed Hasil dari API Telegram, atau false jika gagal.
      */
-    public function sendMessage($chat_id, $text, $parse_mode = null, $reply_markup = null, $reply_parameters = null) {
+    public function sendMessage($chat_id, $text, $parse_mode = null, $reply_markup = null, $message_thread_id = null, $reply_parameters = null) {
         $data = [
             'chat_id' => $chat_id,
             'text' => $text,
@@ -186,6 +186,9 @@ class TelegramAPI {
         }
         if ($reply_markup) {
             $data['reply_markup'] = $reply_markup;
+        }
+        if ($message_thread_id) {
+            $data['message_thread_id'] = $message_thread_id;
         }
         if ($reply_parameters) {
             $data['reply_parameters'] = json_encode($reply_parameters);

--- a/core/handlers/CallbackQueryHandler.php
+++ b/core/handlers/CallbackQueryHandler.php
@@ -99,7 +99,7 @@ class CallbackQueryHandler
         // 5. Try to post based on whether a discussion group is linked
         try {
             if ($linked_chat_id) {
-                // Case A: Discussion group exists. Post to channel without keyboard, then send a new message with keyboard to the group.
+                // Case A: Discussion group exists. Post to channel, then post to the discussion thread.
                 $channel_post_result = $this->telegram_api->copyMessage(
                     $channel_id,
                     $thumbnail['chat_id'],
@@ -114,12 +114,16 @@ class CallbackQueryHandler
                     throw new Exception($channel_post_result['description'] ?? 'Gagal mengirim pesan ke channel.');
                 }
 
-                // Send a new message with the keyboard to the discussion group
+                // The message_id of the post in the channel becomes the message_thread_id for the discussion group
+                $message_thread_id = $channel_post_result['result']['message_id'];
+
+                // Send a new message with the keyboard to the discussion group's topic
                 $this->telegram_api->sendMessage(
                     $linked_chat_id,
-                    $caption,
+                    "⬇️ Tombol aksi untuk postingan di atas ⬇️",
                     'Markdown',
-                    $reply_markup
+                    $reply_markup,
+                    $message_thread_id
                 );
 
             } else {


### PR DESCRIPTION
Implements the correct logic for posting to a channel with a linked discussion group, based on user's technical feedback.

- The `sendMessage` method in `TelegramAPI.php` is updated to support the `message_thread_id` parameter.
- When posting to a channel with a linked discussion group:
  1. The content is first posted to the channel without an inline keyboard.
  2. The `message_id` of this new channel post is retrieved.
  3. A new message containing the action keyboard is sent to the linked discussion group, using the channel post's ID as the `message_thread_id`. This correctly places the keyboard message within the channel post's comment thread.
- Channels without a discussion group retain the original behavior.