### PR TITLE
feat: Tambahkan halaman tes API langsung untuk admin

### DIFF
--- a/admin/api_test.php
+++ b/admin/api_test.php
@@ -1,0 +1,157 @@
+<?php
+require_once __DIR__ . '/../core/database.php';
+require_once __DIR__ . '/../core/helpers.php';
+require_once __DIR__ . '/../core/TelegramAPI.php';
+
+$pdo = get_db_connection();
+if (!$pdo) {
+    die("Koneksi database gagal.");
+}
+
+// Ambil semua bot untuk dropdown
+$bots = $pdo->query("SELECT id, first_name, token FROM bots ORDER BY first_name")->fetchAll();
+
+$selected_bot_token = null;
+$api_response = null;
+$error = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bot_token'])) {
+    $selected_bot_token = $_POST['bot_token'];
+    $method = $_POST['method'] ?? '';
+    $params = $_POST['params'] ?? [];
+
+    if ($selected_bot_token && $method) {
+        try {
+            $telegram_api = new TelegramAPI($selected_bot_token, $pdo);
+
+            // Bersihkan parameter kosong
+            $params = array_filter($params, function($value) {
+                return $value !== '' && $value !== null;
+            });
+
+            if (method_exists($telegram_api, $method)) {
+                // Panggil metode secara dinamis
+                $api_response = call_user_func_array([$telegram_api, $method], $params);
+            } else {
+                $error = "Metode '{$method}' tidak ada di kelas TelegramAPI.";
+            }
+        } catch (Exception $e) {
+            $error = "Exception: " . $e->getMessage();
+            $api_response = ['error' => $error];
+        }
+    } else {
+        $error = "Silakan pilih bot dan metode.";
+    }
+}
+
+$page_title = 'Tes API Langsung';
+include __DIR__ . '/partials/header.php';
+?>
+
+<h1>Tes API Langsung untuk Metode Bot</h1>
+<p>Halaman ini memungkinkan Anda untuk menguji berbagai metode API Telegram secara langsung.</p>
+
+<form action="api_test.php" method="post" id="api-selector-form">
+    <div style="margin-bottom: 15px;">
+        <label for="bot_token"><strong>Pilih Bot untuk Diuji:</strong></label>
+        <select name="bot_token" id="bot_token" onchange="this.form.submit()">
+            <option value="">-- Pilih Bot --</option>
+            <?php foreach ($bots as $bot): ?>
+                <option value="<?= htmlspecialchars($bot['token']) ?>" <?= ($selected_bot_token === $bot['token']) ? 'selected' : '' ?>>
+                    <?= htmlspecialchars($bot['first_name']) ?>
+                </option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+</form>
+
+<?php if ($selected_bot_token): ?>
+    <hr>
+    <h2>Pilih Metode API</h2>
+    <?php
+    $telegram_api_reflection = new ReflectionClass('TelegramAPI');
+    $public_methods = $telegram_api_reflection->getMethods(ReflectionMethod::IS_PUBLIC);
+
+    // Metode yang tidak ingin ditampilkan (misalnya, konstruktor, metode internal)
+    $excluded_methods = ['__construct', '__call', 'escapeMarkdown', 'getBotId', 'sendLongMessage'];
+
+    foreach ($public_methods as $method) {
+        if (in_array($method->getName(), $excluded_methods) || strpos($method->getName(), 'handle') === 0 || strpos($method->getName(), 'apiRequest') === 0) {
+            continue;
+        }
+    ?>
+        <div class="api-method-form">
+            <h3><?= $method->getName() ?></h3>
+            <form action="api_test.php" method="post">
+                <input type="hidden" name="bot_token" value="<?= htmlspecialchars($selected_bot_token) ?>">
+                <input type="hidden" name="method" value="<?= $method->getName() ?>">
+
+                <?php
+                $parameters = $method->getParameters();
+                if (empty($parameters)) {
+                    echo "<p>Metode ini tidak memerlukan parameter.</p>";
+                } else {
+                    foreach ($parameters as $param) {
+                ?>
+                    <div style="margin-bottom: 10px;">
+                        <label for="param-<?= $method->getName() ?>-<?= $param->getName() ?>">
+                            <?= $param->getName() ?>
+                            <?= $param->isOptional() ? '<em>(opsional)</em>' : '<strong style="color:red;">*</strong>' ?>
+                        </label>
+                        <br>
+                        <?php if (strlen($param->getName()) > 10 && (stripos($param->getName(), 'json') !== false || stripos($param->getName(), 'markup') !== false || stripos($param->getName(), 'results') !== false || stripos($param->getName(), 'media') !== false)): ?>
+                            <textarea
+                                name="params[<?= $param->getName() ?>]"
+                                id="param-<?= $method->getName() ?>-<?= $param->getName() ?>"
+                                rows="3"
+                                placeholder="<?= htmlspecialchars($param->getName()) ?> (JSON-encoded)"></textarea>
+                        <?php else: ?>
+                            <input
+                                type="text"
+                                name="params[<?= $param->getName() ?>]"
+                                id="param-<?= $method->getName() ?>-<?= $param->getName() ?>"
+                                placeholder="<?= htmlspecialchars($param->getName()) ?>">
+                        <?php endif; ?>
+                    </div>
+                <?php
+                    }
+                }
+                ?>
+                <button type="submit">Jalankan <?= $method->getName() ?></button>
+            </form>
+        </div>
+        <hr>
+    <?php } ?>
+<?php endif; ?>
+
+<?php if ($api_response !== null || $error !== null): ?>
+    <h2>Hasil API</h2>
+    <?php if ($error): ?>
+        <div class="alert alert-danger">
+            <strong>Error:</strong> <?= htmlspecialchars($error) ?>
+        </div>
+    <?php endif; ?>
+    <pre style="background-color: #eee; padding: 15px; border-radius: 5px; white-space: pre-wrap; word-wrap: break-word;"><?= htmlspecialchars(json_encode($api_response, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)) ?></pre>
+<?php endif; ?>
+
+<style>
+    .api-method-form {
+        margin-bottom: 20px;
+        padding: 15px;
+        border: 1px solid #ddd;
+        border-radius: 5px;
+    }
+    .api-method-form h3 {
+        margin-top: 0;
+    }
+    textarea {
+        width: calc(100% - 22px);
+        padding: 10px;
+        margin-bottom: 10px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        font-family: monospace;
+    }
+</style>
+
+<?php include __DIR__ . '/partials/footer.php'; ?>

--- a/admin/bots.php
+++ b/admin/bots.php
@@ -1,5 +1,4 @@
 <?php
-session_start();
 require_once __DIR__ . '/../core/database.php';
 require_once __DIR__ . '/../core/helpers.php';
 require_once __DIR__ . '/../core/TelegramAPI.php';
@@ -58,96 +57,56 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['add_bot'])) {
 // Ambil daftar bot yang ada
 $bots = $pdo->query("SELECT id, first_name, username, token, created_at FROM bots ORDER BY created_at DESC")->fetchAll();
 
+$page_title = 'Kelola Bot';
+include __DIR__ . '/partials/header.php';
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Kelola Bot - Admin Panel</title>
-    <style>
-        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 40px; background-color: #f4f6f8; color: #333; }
-        .container { max-width: 800px; margin: 0 auto; background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
-        h1, h2 { color: #333; }
-        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
-        th, td { padding: 12px; border: 1px solid #ddd; text-align: left; }
-        th { background-color: #f2f2f2; }
-        form { margin-top: 20px; padding: 20px; border: 1px solid #ddd; border-radius: 5px; background-color: #f9f9f9; }
-        input[type="text"] { width: calc(100% - 22px); padding: 10px; margin-bottom: 10px; border: 1px solid #ccc; border-radius: 4px; }
-        button { padding: 10px 15px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; }
-        button:hover { background-color: #0056b3; }
-        .btn-edit { display: inline-block; padding: 5px 10px; background-color: #28a745; color: white; text-decoration: none; border-radius: 4px; }
-        .btn-edit:hover { background-color: #218838; }
-        .alert { padding: 15px; margin-bottom: 20px; border-radius: 4px; word-wrap: break-word; }
-        .alert-danger { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
-        .alert-success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
-        nav { margin-bottom: 20px; }
-        nav a { text-decoration: none; color: #007bff; padding: 10px; }
-        nav a.active { font-weight: bold; }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <nav>
-            <a href="index.php">Percakapan</a> |
-            <a href="bots.php" class="active">Kelola Bot</a> |
-            <a href="users.php">Pengguna</a> |
-            <a href="roles.php">Manajemen Peran</a> |
-            <a href="packages.php">Konten</a> |
-            <a href="media_logs.php">Log Media</a> |
-            <a href="channels.php">Channel</a> |
-            <a href="database.php">Database</a> |
-            <a href="logs.php">Logs</a> |
-            <a href="telegram_logs.php">Log Error Telegram</a>
-        </nav>
 
-        <h1>Kelola Bot Telegram</h1>
+<h1>Kelola Bot Telegram</h1>
 
-        <?php if ($error): ?>
-            <div class="alert alert-danger"><?= htmlspecialchars($error) ?></div>
-        <?php endif; ?>
-        <?php if ($success): ?>
-            <div class="alert alert-success"><?= $success ?></div>
-        <?php endif; ?>
+<?php if ($error): ?>
+    <div class="alert alert-danger"><?= htmlspecialchars($error) ?></div>
+<?php endif; ?>
+<?php if ($success): ?>
+    <div class="alert alert-success"><?= $success ?></div>
+<?php endif; ?>
 
-        <h2>Tambah Bot Baru</h2>
-        <form action="bots.php" method="post">
-            <input type="text" name="token" placeholder="Token API dari BotFather" required>
-            <button type="submit" name="add_bot">Tambah Bot</button>
-        </form>
+<h2>Tambah Bot Baru</h2>
+<form action="bots.php" method="post">
+    <input type="text" name="token" placeholder="Token API dari BotFather" required>
+    <button type="submit" name="add_bot">Tambah Bot</button>
+</form>
 
-        <h2>Daftar Bot</h2>
-        <table>
-            <thead>
+<h2>Daftar Bot</h2>
+<table>
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Nama</th>
+            <th>Username</th>
+            <th>Aksi</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php if (empty($bots)): ?>
+            <tr>
+                <td colspan="4" style="text-align: center;">Belum ada bot yang ditambahkan.</td>
+            </tr>
+        <?php else: ?>
+            <?php foreach ($bots as $bot): ?>
+                <?php
+                    $telegram_bot_id = explode(':', $bot['token'])[0];
+                ?>
                 <tr>
-                    <th>ID</th>
-                    <th>Nama</th>
-                    <th>Username</th>
-                    <th>Aksi</th>
+                    <td><?= htmlspecialchars($telegram_bot_id) ?></td>
+                    <td><?= htmlspecialchars($bot['first_name']) ?></td>
+                    <td>@<?= htmlspecialchars($bot['username'] ?? 'N/A') ?></td>
+                    <td>
+                        <a href="edit_bot.php?id=<?= htmlspecialchars($telegram_bot_id) ?>" class="btn btn-edit">Edit</a>
+                    </td>
                 </tr>
-            </thead>
-            <tbody>
-                <?php if (empty($bots)): ?>
-                    <tr>
-                        <td colspan="4" style="text-align: center;">Belum ada bot yang ditambahkan.</td>
-                    </tr>
-                <?php else: ?>
-                    <?php foreach ($bots as $bot): ?>
-                        <?php
-                            $telegram_bot_id = explode(':', $bot['token'])[0];
-                        ?>
-                        <tr>
-                            <td><?= htmlspecialchars($telegram_bot_id) ?></td>
-                            <td><?= htmlspecialchars($bot['first_name']) ?></td>
-                            <td>@<?= htmlspecialchars($bot['username'] ?? 'N/A') ?></td>
-                            <td>
-                                <a href="edit_bot.php?id=<?= htmlspecialchars($telegram_bot_id) ?>" class="btn-edit">Edit</a>
-                            </td>
-                        </tr>
-                    <?php endforeach; ?>
-                <?php endif; ?>
-            </tbody>
-        </table>
-    </div>
-</body>
-</html>
+            <?php endforeach; ?>
+        <?php endif; ?>
+    </tbody>
+</table>
+
+<?php include __DIR__ . '/partials/footer.php'; ?>

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,5 +1,4 @@
 <?php
-session_start();
 require_once __DIR__ . '/../core/database.php';
 require_once __DIR__ . '/../core/helpers.php';
 
@@ -71,102 +70,64 @@ if ($selected_telegram_bot_id) {
     }
 }
 
+$page_title = 'Percakapan';
+include __DIR__ . '/partials/header.php';
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Percakapan - Admin Panel</title>
-    <style>
-        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 40px; background-color: #f4f6f8; color: #333; }
-        .container { max-width: 900px; margin: 0 auto; background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
-        h1 { color: #333; }
-        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
-        th, td { padding: 12px; border: 1px solid #ddd; text-align: left; }
-        th { background-color: #f2f2f2; }
-        tr:hover { background-color: #f1f1f1; }
-        .bot-selector { margin-bottom: 20px; }
-        label { font-weight: bold; margin-right: 10px; }
-        select { padding: 8px; border-radius: 4px; border: 1px solid #ccc; }
-        nav { margin-bottom: 20px; }
-        nav a { text-decoration: none; color: #007bff; padding: 10px; }
-        nav a.active { font-weight: bold; }
-        a { color: #007bff; text-decoration: none; }
-        .last-message { color: #555; font-size: 0.9em; }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <nav>
-            <a href="index.php" class="active">Percakapan</a> |
-            <a href="bots.php">Kelola Bot</a> |
-            <a href="users.php">Pengguna</a> |
-            <a href="roles.php">Manajemen Peran</a> |
-            <a href="packages.php">Konten</a> |
-            <a href="media_logs.php">Log Media</a> |
-            <a href="channels.php">Channel</a> |
-            <a href="database.php">Database</a> |
-            <a href="logs.php">Logs</a> |
-            <a href="telegram_logs.php">Log Error Telegram</a>
-        </nav>
 
-        <h1>Daftar Percakapan</h1>
+<h1>Daftar Percakapan</h1>
 
-        <div class="bot-selector">
-            <form action="index.php" method="get">
-                <label for="bot_id">Pilih Bot:</label>
-                <select name="bot_id" id="bot_id" onchange="this.form.submit()">
-                    <option value="">-- Pilih Bot --</option>
-                    <?php foreach ($bots as $bot): ?>
-                        <?php $telegram_bot_id = explode(':', $bot['token'])[0]; ?>
-                        <option value="<?= $telegram_bot_id ?>" <?= ($selected_telegram_bot_id == $telegram_bot_id) ? 'selected' : '' ?>>
-                            <?= htmlspecialchars($bot['first_name'] ?? 'Bot Tanpa Nama') ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            </form>
-        </div>
+<div class="bot-selector">
+    <form action="index.php" method="get" style="padding: 0; border: none; background: none;">
+        <label for="bot_id">Pilih Bot:</label>
+        <select name="bot_id" id="bot_id" onchange="this.form.submit()">
+            <option value="">-- Pilih Bot --</option>
+            <?php foreach ($bots as $bot): ?>
+                <?php $telegram_bot_id = explode(':', $bot['token'])[0]; ?>
+                <option value="<?= $telegram_bot_id ?>" <?= ($selected_telegram_bot_id == $telegram_bot_id) ? 'selected' : '' ?>>
+                    <?= htmlspecialchars($bot['first_name'] ?? 'Bot Tanpa Nama') ?>
+                </option>
+            <?php endforeach; ?>
+        </select>
+    </form>
+</div>
 
-        <?php if ($selected_telegram_bot_id): ?>
-            <?php if (!$internal_bot_id): ?>
-                <p>Bot dengan ID <?= htmlspecialchars($selected_telegram_bot_id) ?> tidak ditemukan.</p>
-            <?php else: ?>
-                <table>
-                    <thead>
+<?php if ($selected_telegram_bot_id): ?>
+    <?php if (!$internal_bot_id): ?>
+        <p>Bot dengan ID <?= htmlspecialchars($selected_telegram_bot_id) ?> tidak ditemukan.</p>
+    <?php else: ?>
+        <table>
+            <thead>
+                <tr>
+                    <th>Nama Pengguna</th>
+                    <th>Username</th>
+                    <th>Pesan Terakhir</th>
+                    <th>Waktu</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php if (empty($conversations)): ?>
+                    <tr>
+                        <td colspan="4">Belum ada percakapan untuk bot ini.</td>
+                    </tr>
+                <?php else: ?>
+                    <?php foreach ($conversations as $conv): ?>
                         <tr>
-                            <th>Nama Pengguna</th>
-                            <th>Username</th>
-                            <th>Pesan Terakhir</th>
-                            <th>Waktu</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php if (empty($conversations)): ?>
-                            <tr>
-                                <td colspan="4">Belum ada percakapan untuk bot ini.</td>
-                            </tr>
-                        <?php else: ?>
-                            <?php foreach ($conversations as $conv): ?>
-                                <tr>
-                                    <td>
-                                        <a href="chat.php?user_id=<?= $conv['user_internal_id'] ?>&bot_id=<?= $internal_bot_id ?>">
-                                            <?= htmlspecialchars($conv['first_name'] ?? '') ?>
-                                        </a>
-                                    </td>
-                                    <td>@<?= htmlspecialchars($conv['username'] ?? '') ?></td>
-                                <td class="last-message"><?= htmlspecialchars(mb_strimwidth($conv['last_message'] ?? '', 0, 50, "...")) ?></td>
-                                <td><?= htmlspecialchars($conv['last_message_time'] ?? '') ?></td>
-                            </tr>
-                        <?php endforeach; ?>
-                    <?php endif; ?>
-                </tbody>
-            </table>
+                            <td>
+                                <a href="chat.php?user_id=<?= $conv['user_internal_id'] ?>&bot_id=<?= $internal_bot_id ?>">
+                                    <?= htmlspecialchars($conv['first_name'] ?? '') ?>
+                                </a>
+                            </td>
+                            <td>@<?= htmlspecialchars($conv['username'] ?? '') ?></td>
+                        <td class="last-message"><?= htmlspecialchars(mb_strimwidth($conv['last_message'] ?? '', 0, 50, "...")) ?></td>
+                        <td><?= htmlspecialchars($conv['last_message_time'] ?? '') ?></td>
+                    </tr>
+                <?php endforeach; ?>
             <?php endif; ?>
-        <?php else: ?>
-            <p>Silakan pilih bot untuk melihat percakapannya.</p>
-        <?php endif; ?>
+        </tbody>
+    </table>
+    <?php endif; ?>
+<?php else: ?>
+    <p>Silakan pilih bot untuk melihat percakapannya.</p>
+<?php endif; ?>
 
-    </div>
-</body>
-</html>
+<?php include __DIR__ . '/partials/footer.php'; ?>

--- a/admin/partials/footer.php
+++ b/admin/partials/footer.php
@@ -1,0 +1,5 @@
+</div> <!-- .content -->
+</main> <!-- .container -->
+
+</body>
+</html>

--- a/admin/partials/header.php
+++ b/admin/partials/header.php
@@ -1,0 +1,66 @@
+<?php
+// Pastikan sesi dimulai
+if (session_status() == PHP_SESSION_NONE) {
+    session_start();
+}
+
+// Dapatkan nama file skrip saat ini untuk menyorot tautan aktif
+$current_page = basename($_SERVER['PHP_SELF']);
+?>
+<!DOCTYPE html>
+<html lang="id">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= $page_title ?? 'Admin Panel' ?></title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; background-color: #f4f6f8; color: #333; }
+        .header { background-color: #fff; box-shadow: 0 2px 4px rgba(0,0,0,0.1); padding: 0 20px; }
+        .nav-container { max-width: 1200px; margin: 0 auto; display: flex; justify-content: space-between; align-items: center; }
+        .nav-container h1 { font-size: 1.5em; color: #333; }
+        nav { display: flex; gap: 5px; overflow-x: auto; padding: 10px 0; }
+        nav a { text-decoration: none; color: #007bff; padding: 10px 15px; border-radius: 5px; white-space: nowrap; }
+        nav a:hover { background-color: #f0f0f0; }
+        nav a.active { font-weight: bold; background-color: #e9ecef; }
+        .container { max-width: 1200px; margin: 20px auto; padding: 20px; }
+        .content { background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        .alert { padding: 15px; margin-bottom: 20px; border-radius: 4px; word-wrap: break-word; }
+        .alert-danger { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
+        .alert-success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
+        h1, h2, h3 { color: #333; }
+        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+        th, td { padding: 12px; border: 1px solid #ddd; text-align: left; vertical-align: top; }
+        th { background-color: #f2f2f2; }
+        form { margin-top: 20px; padding: 20px; border: 1px solid #ddd; border-radius: 5px; background-color: #f9f9f9; }
+        input[type="text"], input[type="number"], input[type="password"], textarea, select { width: calc(100% - 22px); padding: 10px; margin-bottom: 10px; border: 1px solid #ccc; border-radius: 4px; }
+        button, .btn { padding: 10px 15px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; text-decoration: none; display: inline-block; }
+        button:hover, .btn:hover { background-color: #0056b3; }
+        .btn-edit { background-color: #28a745; }
+        .btn-edit:hover { background-color: #218838; }
+        .btn-delete { background-color: #dc3545; }
+        .btn-delete:hover { background-color: #c82333; }
+    </style>
+</head>
+<body>
+
+<header class="header">
+    <div class="nav-container">
+        <nav>
+            <a href="index.php" class="<?= $current_page == 'index.php' ? 'active' : '' ?>">Percakapan</a>
+            <a href="bots.php" class="<?= $current_page == 'bots.php' || $current_page == 'edit_bot.php' ? 'active' : '' ?>">Kelola Bot</a>
+            <a href="users.php" class="<?= $current_page == 'users.php' ? 'active' : '' ?>">Pengguna</a>
+            <a href="roles.php" class="<?= $current_page == 'roles.php' ? 'active' : '' ?>">Manajemen Peran</a>
+            <a href="packages.php" class="<?= $current_page == 'packages.php' ? 'active' : '' ?>">Konten</a>
+            <a href="media_logs.php" class="<?= $current_page == 'media_logs.php' ? 'active' : '' ?>">Log Media</a>
+            <a href="channels.php" class="<?= $current_page == 'channels.php' ? 'active' : '' ?>">Channel</a>
+            <a href="database.php" class="<?= $current_page == 'database.php' ? 'active' : '' ?>">Database</a>
+            <a href="logs.php" class="<?= $current_page == 'logs.php' ? 'active' : '' ?>">Logs</a>
+            <a href="telegram_logs.php" class="<?= $current_page == 'telegram_logs.php' ? 'active' : '' ?>">Log Error Telegram</a>
+            <a href="api_test.php" class="<?= $current_page == 'api_test.php' ? 'active' : '' ?>">Tes API</a>
+        </nav>
+    </div>
+</header>
+
+<main class="container">
+    <div class="content">
+        <!-- Konten utama halaman akan dimulai di sini -->

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,5 +1,4 @@
 <?php
-session_start();
 require_once __DIR__ . '/../core/database.php';
 require_once __DIR__ . '/../core/helpers.php';
 
@@ -65,20 +64,22 @@ $search_term = isset($_GET['search']) ? trim($_GET['search']) : '';
 $where_clause = '';
 $params = [];
 if (!empty($search_term)) {
-    $where_clause = "WHERE id = ? OR telegram_id = ? OR first_name LIKE ? OR last_name LIKE ? OR username LIKE ?";
+    $where_clause = "WHERE u.id = ? OR u.telegram_id = ? OR u.first_name LIKE ? OR u.last_name LIKE ? OR u.username LIKE ?";
     $params = [$search_term, $search_term, "%$search_term%", "%$search_term%", "%$search_term%"];
 }
+
 
 // --- Logic untuk Sort ---
 $sort_columns = ['id', 'telegram_id', 'first_name', 'last_name', 'username', 'balance', 'created_at'];
 $sort_by = isset($_GET['sort']) && in_array($_GET['sort'], $sort_columns) ? $_GET['sort'] : 'id';
 $order = isset($_GET['order']) && strtolower($_GET['order']) === 'asc' ? 'ASC' : 'DESC';
-$order_by_clause = "ORDER BY {$sort_by} {$order}";
+$order_by_clause = "ORDER BY u.{$sort_by} {$order}";
 
 // --- Ambil data pengguna dari database ---
-$stmt = $pdo->prepare("SELECT * FROM users {$where_clause} {$order_by_clause}");
+$stmt = $pdo->prepare("SELECT u.* FROM users u {$where_clause} {$order_by_clause}");
 $stmt->execute($params);
 $users = $stmt->fetchAll();
+
 
 // Helper function untuk membuat link sort
 function get_sort_link($column, $current_sort, $current_order) {
@@ -90,136 +91,89 @@ function get_sort_link($column, $current_sort, $current_order) {
     return "users.php?sort={$column}&order={$new_order}" . ($GLOBALS['search_term'] ? '&search=' . urlencode($GLOBALS['search_term']) : '') . $arrow;
 }
 
+$page_title = 'Manajemen Pengguna';
+include __DIR__ . '/partials/header.php';
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Manajemen Pengguna - Admin Panel</title>
-    <style>
-        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 40px; background-color: #f4f6f8; color: #333; }
-        .container { max-width: 1200px; margin: 0 auto; background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
-        h1, h2 { color: #333; }
-        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
-        th, td { padding: 12px; border: 1px solid #ddd; text-align: left; vertical-align: top; }
-        th { background-color: #f2f2f2; }
-        tr:hover { background-color: #f1f1f1; }
-        nav { margin-bottom: 20px; }
-        nav a { text-decoration: none; color: #007bff; padding: 10px; }
-        nav a.active { font-weight: bold; }
-        a { color: #007bff; text-decoration: none; }
-        .search-form { margin-bottom: 20px; }
-        .search-form input[type="text"] { padding: 8px; width: 300px; border-radius: 4px; border: 1px solid #ccc; }
-        .search-form button { padding: 8px 12px; border-radius: 4px; border: none; background-color: #007bff; color: white; cursor: pointer; }
-        .bot-list { list-style-type: none; padding: 0; margin: 0; }
-        .bot-list li { display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px; }
-        .action-btn { font-size: 0.8em; padding: 2px 6px; border-radius: 3px; color: white; border: none; cursor: pointer; }
-        .btn-block { background-color: #dc3545; }
-        .btn-unblock { background-color: #28a745; }
-        .balance-form input { width: 100px; padding: 4px; border-radius: 3px; border: 1px solid #ccc; }
-        .balance-form button { padding: 4px 8px; }
-        .message { padding: 10px; margin-bottom: 15px; border-radius: 4px; color: #fff; }
-        .message.success { background-color: #28a745; }
-        .message.error { background-color: #dc3545; }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <nav>
-            <a href="index.php">Percakapan</a> |
-            <a href="bots.php">Kelola Bot</a> |
-            <a href="users.php" class="active">Pengguna</a> |
-            <a href="roles.php">Manajemen Peran</a> |
-            <a href="packages.php">Konten</a> |
-            <a href="media_logs.php">Log Media</a> |
-            <a href="channels.php">Channel</a> |
-            <a href="database.php">Database</a> |
-            <a href="logs.php">Logs</a> |
-            <a href="telegram_logs.php">Log Error Telegram</a>
-        </nav>
 
-        <h1>Manajemen Pengguna</h1>
+<h1>Manajemen Pengguna</h1>
 
-        <?php if (!empty($message)): ?>
-            <div class="message success"><?= htmlspecialchars($message) ?></div>
+<?php if (!empty($message)): ?>
+    <div class="alert alert-success"><?= htmlspecialchars($message) ?></div>
+<?php endif; ?>
+
+<div class="search-form">
+    <form action="users.php" method="get" style="padding:0; border:none; background:none;">
+        <input type="text" name="search" placeholder="Cari ID, Nama, Username..." value="<?= htmlspecialchars($search_term) ?>">
+        <button type="submit">Cari</button>
+    </form>
+</div>
+
+<table>
+    <thead>
+        <tr>
+            <th><a href="<?= get_sort_link('id', $sort_by, $order) ?>">ID</a></th>
+            <th><a href="<?= get_sort_link('telegram_id', $sort_by, $order) ?>">Telegram ID</a></th>
+            <th><a href="<?= get_sort_link('first_name', $sort_by, $order) ?>">Nama</a></th>
+            <th><a href="<?= get_sort_link('username', $sort_by, $order) ?>">Username</a></th>
+            <th><a href="<?= get_sort_link('balance', $sort_by, $order) ?>">Saldo</a></th>
+            <th>Bot Terkait & Aksi</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php if (empty($users)): ?>
+            <tr>
+                <td colspan="6">Tidak ada pengguna yang cocok dengan kriteria.</td>
+            </tr>
+        <?php else: ?>
+            <?php foreach ($users as $user): ?>
+            <tr>
+                <td><?= htmlspecialchars($user['id']) ?></td>
+                <td><?= htmlspecialchars($user['telegram_id']) ?></td>
+                <td><?= htmlspecialchars(trim(($user['first_name'] ?? '') . ' ' . ($user['last_name'] ?? ''))) ?></td>
+                <td>@<?= htmlspecialchars($user['username'] ?? '') ?></td>
+                <td>
+                    <form action="users.php?<?= http_build_query($_GET) ?>" method="post" class="balance-form" style="padding:0; border:none; background:none;">
+                        <input type="hidden" name="action" value="update_balance">
+                        <input type="hidden" name="user_id" value="<?= $user['id'] ?>">
+                        <input type="number" name="balance" value="<?= htmlspecialchars($user['balance']) ?>" step="any" required>
+                        <button type="submit" class="btn" style="padding: 4px 8px;">Simpan</button>
+                    </form>
+                </td>
+                <td>
+                    <?php
+                        $related_bots_stmt = $pdo->prepare(
+                            "SELECT b.id, b.first_name, r.is_blocked
+                             FROM bots b
+                             JOIN rel_user_bot r ON b.id = r.bot_id
+                             WHERE r.user_id = ?"
+                        );
+                        $related_bots_stmt->execute([$user['id']]);
+                        $related_bots = $related_bots_stmt->fetchAll();
+                    ?>
+                    <ul class="bot-list" style="list-style: none; padding: 0; margin: 0;">
+                        <?php foreach ($related_bots as $related_bot): ?>
+                            <li style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
+                                <span>
+                                    <a href="chat.php?user_id=<?= $user['id'] ?>&bot_id=<?= $related_bot['id'] ?>">
+                                        <?= htmlspecialchars($related_bot['first_name']) ?>
+                                    </a>
+                                    (<?= $related_bot['is_blocked'] ? 'Diblokir' : 'Aktif' ?>)
+                                </span>
+                                <form action="users.php?<?= http_build_query($_GET) ?>" method="post" style="display: inline; padding:0; border:none; background:none;">
+                                    <input type="hidden" name="action" value="toggle_block">
+                                    <input type="hidden" name="user_id" value="<?= $user['id'] ?>">
+                                    <input type="hidden" name="bot_id" value="<?= $related_bot['id'] ?>">
+                                    <button type="submit" class="btn <?= $related_bot['is_blocked'] ? 'btn-edit' : 'btn-delete' ?>" style="padding: 2px 6px; font-size: 0.8em;">
+                                        <?= $related_bot['is_blocked'] ? 'Buka Blokir' : 'Blokir' ?>
+                                    </button>
+                                </form>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                </td>
+            </tr>
+            <?php endforeach; ?>
         <?php endif; ?>
-
-        <div class="search-form">
-            <form action="users.php" method="get">
-                <input type="text" name="search" placeholder="Cari ID, Nama, Username..." value="<?= htmlspecialchars($search_term) ?>">
-                <button type="submit">Cari</button>
-            </form>
-        </div>
-
-        <table>
-            <thead>
-                <tr>
-                    <th><a href="<?= get_sort_link('id', $sort_by, $order) ?>">ID</a></th>
-                    <th><a href="<?= get_sort_link('telegram_id', $sort_by, $order) ?>">Telegram ID</a></th>
-                    <th><a href="<?= get_sort_link('first_name', $sort_by, $order) ?>">Nama</a></th>
-                    <th><a href="<?= get_sort_link('username', $sort_by, $order) ?>">Username</a></th>
-                    <th><a href="<?= get_sort_link('balance', $sort_by, $order) ?>">Saldo</a></th>
-                    <th>Bot Terkait & Aksi</th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php if (empty($users)): ?>
-                    <tr>
-                        <td colspan="6">Tidak ada pengguna yang cocok dengan kriteria.</td>
-                    </tr>
-                <?php else: ?>
-                    <?php foreach ($users as $user): ?>
-                    <tr>
-                        <td><?= htmlspecialchars($user['id']) ?></td>
-                        <td><?= htmlspecialchars($user['telegram_id']) ?></td>
-                        <td><?= htmlspecialchars(trim(($user['first_name'] ?? '') . ' ' . ($user['last_name'] ?? ''))) ?></td>
-                        <td>@<?= htmlspecialchars($user['username'] ?? '') ?></td>
-                        <td>
-                            <form action="users.php?<?= http_build_query($_GET) ?>" method="post" class="balance-form">
-                                <input type="hidden" name="action" value="update_balance">
-                                <input type="hidden" name="user_id" value="<?= $user['id'] ?>">
-                                <input type="number" name="balance" value="<?= htmlspecialchars($user['balance']) ?>" step="any" required>
-                                <button type="submit" class="action-btn btn-unblock">Simpan</button>
-                            </form>
-                        </td>
-                        <td>
-                            <?php
-                                $related_bots_stmt = $pdo->prepare(
-                                    "SELECT b.id, b.first_name, r.is_blocked
-                                     FROM bots b
-                                     JOIN rel_user_bot r ON b.id = r.bot_id
-                                     WHERE r.user_id = ?"
-                                );
-                                $related_bots_stmt->execute([$user['id']]);
-                                $related_bots = $related_bots_stmt->fetchAll();
-                            ?>
-                            <ul class="bot-list">
-                                <?php foreach ($related_bots as $related_bot): ?>
-                                    <li>
-                                        <span>
-                                            <a href="chat.php?user_id=<?= $user['id'] ?>&bot_id=<?= $related_bot['id'] ?>">
-                                                <?= htmlspecialchars($related_bot['first_name']) ?>
-                                            </a>
-                                            (<?= $related_bot['is_blocked'] ? 'Diblokir' : 'Aktif' ?>)
-                                        </span>
-                                        <form action="users.php?<?= http_build_query($_GET) ?>" method="post" style="display: inline;">
-                                            <input type="hidden" name="action" value="toggle_block">
-                                            <input type="hidden" name="user_id" value="<?= $user['id'] ?>">
-                                            <input type="hidden" name="bot_id" value="<?= $related_bot['id'] ?>">
-                                            <button type="submit" class="action-btn <?= $related_bot['is_blocked'] ? 'btn-unblock' : 'btn-block' ?>">
-                                                <?= $related_bot['is_blocked'] ? 'Buka Blokir' : 'Blokir' ?>
-                                            </button>
-                                        </form>
-                                    </li>
-                                <?php endforeach; ?>
-                            </ul>
-                        </td>
-                    </tr>
-                    <?php endforeach; ?>
-                <?php endif; ?>
-            </tbody>
-        </table>
-    </div>
-</body>
-</html>
+    </tbody>
+</table>
+<?php include __DIR__ . '/partials/footer.php'; ?>


### PR DESCRIPTION
Menambahkan halaman baru di bawah panel admin (`/admin/api_test.php`) yang memungkinkan pengujian langsung semua metode publik dari kelas `TelegramAPI`.

Fitur:
- Pemilihan bot dari dropdown untuk melakukan panggilan API.
- Secara dinamis membuat formulir untuk setiap metode API menggunakan Refleksi PHP.
- Menyediakan kolom input untuk setiap parameter metode, dengan label yang sesuai dan indikator opsional.
- Mengirimkan permintaan API ke Telegram dan menampilkan respons mentah dalam format JSON yang cantik.

Sebagai bagian dari implementasi ini, beberapa halaman admin (`index.php`, `bots.php`, `users.php`) direfaktor untuk menggunakan header dan footer parsial umum (`partials/header.php`, `partials/footer.php`). Ini menyatukan tata letak dan navigasi di seluruh panel admin dan memungkinkan penambahan tautan 'Tes API' dengan mudah.