### PR TITLE
feat: Halaman Tes Langsung API Admin dengan AJAX dan Riwayat

### DIFF
--- a/admin/api_test.php
+++ b/admin/api_test.php
@@ -1,7 +1,6 @@
 <?php
 require_once __DIR__ . '/../core/database.php';
 require_once __DIR__ . '/../core/helpers.php';
-require_once __DIR__ . '/../core/TelegramAPI.php';
 
 $pdo = get_db_connection();
 if (!$pdo) {
@@ -10,148 +9,257 @@ if (!$pdo) {
 
 // Ambil semua bot untuk dropdown
 $bots = $pdo->query("SELECT id, first_name, token FROM bots ORDER BY first_name")->fetchAll();
-
-$selected_bot_token = null;
-$api_response = null;
-$error = null;
-
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bot_token'])) {
-    $selected_bot_token = $_POST['bot_token'];
-    $method = $_POST['method'] ?? '';
-    $params = $_POST['params'] ?? [];
-
-    if ($selected_bot_token && $method) {
-        try {
-            $telegram_api = new TelegramAPI($selected_bot_token, $pdo);
-
-            // Bersihkan parameter kosong
-            $params = array_filter($params, function($value) {
-                return $value !== '' && $value !== null;
-            });
-
-            if (method_exists($telegram_api, $method)) {
-                // Panggil metode secara dinamis
-                $api_response = call_user_func_array([$telegram_api, $method], $params);
-            } else {
-                $error = "Metode '{$method}' tidak ada di kelas TelegramAPI.";
-            }
-        } catch (Exception $e) {
-            $error = "Exception: " . $e->getMessage();
-            $api_response = ['error' => $error];
-        }
-    } else {
-        $error = "Silakan pilih bot dan metode.";
-    }
-}
+$selected_bot_id = $_GET['bot_id'] ?? ($bots[0]['id'] ?? null);
 
 $page_title = 'Tes API Langsung';
 include __DIR__ . '/partials/header.php';
 ?>
 
-<h1>Tes API Langsung untuk Metode Bot</h1>
-<p>Halaman ini memungkinkan Anda untuk menguji berbagai metode API Telegram secara langsung.</p>
+<div class="api-tester-container">
+    <h1>Tes API Langsung untuk Metode Bot</h1>
+    <p>Pilih bot, pilih metode, isi parameter, dan jalankan permintaan secara real-time.</p>
 
-<form action="api_test.php" method="post" id="api-selector-form">
-    <div style="margin-bottom: 15px;">
-        <label for="bot_token"><strong>Pilih Bot untuk Diuji:</strong></label>
-        <select name="bot_token" id="bot_token" onchange="this.form.submit()">
-            <option value="">-- Pilih Bot --</option>
+    <form id="bot-selector-form" class="form-section">
+        <label for="bot_id"><strong>Pilih Bot:</strong></label>
+        <select name="bot_id" id="bot_id">
             <?php foreach ($bots as $bot): ?>
-                <option value="<?= htmlspecialchars($bot['token']) ?>" <?= ($selected_bot_token === $bot['token']) ? 'selected' : '' ?>>
+                <option value="<?= htmlspecialchars($bot['id']) ?>" <?= ($selected_bot_id == $bot['id']) ? 'selected' : '' ?>>
                     <?= htmlspecialchars($bot['first_name']) ?>
                 </option>
             <?php endforeach; ?>
         </select>
-    </div>
-</form>
+    </form>
 
-<?php if ($selected_bot_token): ?>
     <hr>
-    <h2>Pilih Metode API</h2>
-    <?php
-    $telegram_api_reflection = new ReflectionClass('TelegramAPI');
-    $public_methods = $telegram_api_reflection->getMethods(ReflectionMethod::IS_PUBLIC);
 
-    // Metode yang tidak ingin ditampilkan (misalnya, konstruktor, metode internal)
-    $excluded_methods = ['__construct', '__call', 'escapeMarkdown', 'getBotId', 'sendLongMessage'];
-
-    foreach ($public_methods as $method) {
-        if (in_array($method->getName(), $excluded_methods) || strpos($method->getName(), 'handle') === 0 || strpos($method->getName(), 'apiRequest') === 0) {
-            continue;
-        }
-    ?>
-        <div class="api-method-form">
-            <h3><?= $method->getName() ?></h3>
-            <form action="api_test.php" method="post">
-                <input type="hidden" name="bot_token" value="<?= htmlspecialchars($selected_bot_token) ?>">
-                <input type="hidden" name="method" value="<?= $method->getName() ?>">
-
-                <?php
-                $parameters = $method->getParameters();
-                if (empty($parameters)) {
-                    echo "<p>Metode ini tidak memerlukan parameter.</p>";
-                } else {
-                    foreach ($parameters as $param) {
-                ?>
-                    <div style="margin-bottom: 10px;">
-                        <label for="param-<?= $method->getName() ?>-<?= $param->getName() ?>">
-                            <?= $param->getName() ?>
-                            <?= $param->isOptional() ? '<em>(opsional)</em>' : '<strong style="color:red;">*</strong>' ?>
-                        </label>
-                        <br>
-                        <?php if (strlen($param->getName()) > 10 && (stripos($param->getName(), 'json') !== false || stripos($param->getName(), 'markup') !== false || stripos($param->getName(), 'results') !== false || stripos($param->getName(), 'media') !== false)): ?>
-                            <textarea
-                                name="params[<?= $param->getName() ?>]"
-                                id="param-<?= $method->getName() ?>-<?= $param->getName() ?>"
-                                rows="3"
-                                placeholder="<?= htmlspecialchars($param->getName()) ?> (JSON-encoded)"></textarea>
-                        <?php else: ?>
-                            <input
-                                type="text"
-                                name="params[<?= $param->getName() ?>]"
-                                id="param-<?= $method->getName() ?>-<?= $param->getName() ?>"
-                                placeholder="<?= htmlspecialchars($param->getName()) ?>">
-                        <?php endif; ?>
-                    </div>
-                <?php
-                    }
-                }
-                ?>
-                <button type="submit">Jalankan <?= $method->getName() ?></button>
-            </form>
+    <div id="api-interaction-section">
+        <div class="form-section">
+            <label for="api-method-selector"><strong>Pilih Metode API:</strong></label>
+            <select id="api-method-selector">
+                <option value="">-- Memuat metode... --</option>
+            </select>
         </div>
-        <hr>
-    <?php } ?>
-<?php endif; ?>
 
-<?php if ($api_response !== null || $error !== null): ?>
-    <h2>Hasil API</h2>
-    <?php if ($error): ?>
-        <div class="alert alert-danger">
-            <strong>Error:</strong> <?= htmlspecialchars($error) ?>
+        <form id="api-params-form" class="form-section">
+            <div id="params-container">
+                <!-- Parameter form fields will be injected here by JavaScript -->
+            </div>
+            <button type_button="submit" id="run-request-btn" style="display: none;">Jalankan Permintaan</button>
+        </form>
+
+        <div id="api-result-container" class="result-section" style="display: none;">
+            <h3>Hasil API</h3>
+            <pre id="api-result"></pre>
         </div>
-    <?php endif; ?>
-    <pre style="background-color: #eee; padding: 15px; border-radius: 5px; white-space: pre-wrap; word-wrap: break-word;"><?= htmlspecialchars(json_encode($api_response, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)) ?></pre>
-<?php endif; ?>
+    </div>
+
+    <hr>
+
+    <div id="history-section" class="history-section">
+        <h2>Riwayat Permintaan</h2>
+        <div id="history-table-container">
+            <!-- History table will be injected here -->
+        </div>
+        <div id="history-pagination">
+            <!-- Pagination controls will be injected here -->
+        </div>
+    </div>
+</div>
 
 <style>
-    .api-method-form {
-        margin-bottom: 20px;
-        padding: 15px;
-        border: 1px solid #ddd;
-        border-radius: 5px;
-    }
-    .api-method-form h3 {
-        margin-top: 0;
-    }
-    textarea {
-        width: calc(100% - 22px);
-        padding: 10px;
-        margin-bottom: 10px;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        font-family: monospace;
-    }
+    .api-tester-container { max-width: 100%; }
+    .form-section { margin-bottom: 20px; padding: 15px; border: 1px solid #ddd; border-radius: 5px; background-color: #f9f9f9; }
+    .result-section, .history-section { margin-top: 20px; }
+    #api-result, #history-table-container { background-color: #eee; padding: 15px; border-radius: 5px; white-space: pre-wrap; word-wrap: break-word; font-family: monospace; }
+    #history-table-container table { width: 100%; font-size: 14px; }
+    #history-table-container table th, #history-table-container table td { white-space: normal; word-break: break-all; }
+    .pagination-btn { margin: 0 5px; }
+    textarea { width: calc(100% - 22px); padding: 10px; border: 1px solid #ccc; border-radius: 4px; font-family: monospace; min-height: 80px; }
 </style>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const botSelector = document.getElementById('bot_id');
+    const methodSelector = document.getElementById('api-method-selector');
+    const paramsContainer = document.getElementById('params-container');
+    const runRequestBtn = document.getElementById('run-request-btn');
+    const apiResultContainer = document.getElementById('api-result-container');
+    const apiResultEl = document.getElementById('api-result');
+    const apiParamsForm = document.getElementById('api-params-form');
+
+    const historyContainer = document.getElementById('history-table-container');
+    const paginationContainer = document.getElementById('history-pagination');
+
+    let methodsData = {};
+    let currentPage = 1;
+
+    const HANDLER_URL = 'api_test_handler.php';
+
+    // --- Fungsi Utama ---
+
+    async function fetchMethods() {
+        methodSelector.innerHTML = '<option value="">-- Memuat metode... --</option>';
+        try {
+            const response = await fetch(`${HANDLER_URL}?action=get_methods`);
+            if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+            const data = await response.json();
+            methodsData = data;
+
+            methodSelector.innerHTML = '<option value="">-- Pilih Metode --</option>';
+            for (const methodName in methodsData) {
+                const option = new Option(methodName, methodName);
+                methodSelector.appendChild(option);
+            }
+        } catch (e) {
+            console.error('Gagal mengambil metode API:', e);
+            methodSelector.innerHTML = '<option value="">-- Gagal memuat --</option>';
+        }
+    }
+
+    function buildParamsForm(methodName) {
+        paramsContainer.innerHTML = '';
+        runRequestBtn.style.display = 'none';
+        if (!methodName || !methodsData[methodName]) return;
+
+        const params = methodsData[methodName].parameters;
+        if (Object.keys(params).length === 0) {
+            paramsContainer.innerHTML = '<p>Metode ini tidak memerlukan parameter.</p>';
+        } else {
+            for (const paramName in params) {
+                const param = params[paramName];
+                const isOptional = param.isOptional;
+                const inputId = `param-${methodName}-${paramName}`;
+
+                let inputHtml = `<div style="margin-bottom: 10px;">
+                    <label for="${inputId}">
+                        ${paramName} ${isOptional ? '<em>(opsional)</em>' : '<strong style="color:red;">*</strong>'}
+                    </label><br>`;
+
+                const useTextarea = paramName.includes('markup') || paramName.includes('media') || paramName.includes('results') || paramName.includes('entities');
+                if (useTextarea) {
+                    inputHtml += `<textarea name="${paramName}" id="${inputId}" rows="3" placeholder="${paramName} (JSON-encoded)"></textarea>`;
+                } else {
+                    inputHtml += `<input type="text" name="${paramName}" id="${inputId}" placeholder="${paramName}">`;
+                }
+                inputHtml += `</div>`;
+                paramsContainer.innerHTML += inputHtml;
+            }
+        }
+        runRequestBtn.style.display = 'block';
+    }
+
+    async function runApiRequest(event) {
+        event.preventDefault();
+        const selectedBotId = botSelector.value;
+        const selectedMethod = methodSelector.value;
+        const formData = new FormData(apiParamsForm);
+        const params = Object.fromEntries(formData.entries());
+
+        apiResultContainer.style.display = 'block';
+        apiResultEl.textContent = 'Menjalankan...';
+
+        try {
+            const response = await fetch(HANDLER_URL, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    action: 'run_method',
+                    bot_id: selectedBotId,
+                    method: selectedMethod,
+                    params: params
+                })
+            });
+            if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+            const result = await response.json();
+
+            let resultString = JSON.stringify(result.api_response, null, 2);
+            apiResultEl.textContent = resultString;
+
+            fetchHistory(1); // Refresh history to show the new request
+        } catch (e) {
+            console.error('Gagal menjalankan permintaan API:', e);
+            apiResultEl.textContent = `Error: ${e.message}`;
+        }
+    }
+
+    async function fetchHistory(page = 1) {
+        currentPage = page;
+        const selectedBotId = botSelector.value;
+        historyContainer.textContent = 'Memuat riwayat...';
+        try {
+            const response = await fetch(`${HANDLER_URL}?action=get_history&bot_id=${selectedBotId}&page=${page}`);
+            if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+            const data = await response.json();
+            renderHistory(data.history);
+            renderPagination(data.pagination);
+        } catch (e) {
+            console.error('Gagal mengambil riwayat:', e);
+            historyContainer.textContent = 'Gagal memuat riwayat.';
+        }
+    }
+
+    function renderHistory(history) {
+        if (history.length === 0) {
+            historyContainer.innerHTML = '<p>Belum ada riwayat untuk bot ini.</p>';
+            return;
+        }
+        let tableHtml = `
+            <table class="table">
+                <thead><tr><th>Waktu</th><th>Metode</th><th>Request</th><th>Response</th></tr></thead>
+                <tbody>`;
+        for (const item of history) {
+            tableHtml += `
+                <tr>
+                    <td>${item.created_at}</td>
+                    <td>${item.method}</td>
+                    <td><pre>${JSON.stringify(JSON.parse(item.request_payload), null, 2)}</pre></td>
+                    <td><pre>${JSON.stringify(JSON.parse(item.response_payload), null, 2)}</pre></td>
+                </tr>`;
+        }
+        tableHtml += `</tbody></table>`;
+        historyContainer.innerHTML = tableHtml;
+    }
+
+    function renderPagination(pagination) {
+        paginationContainer.innerHTML = '';
+        if (pagination.total_pages <= 1) return;
+
+        let paginationHtml = 'Halaman: ';
+        for (let i = 1; i <= pagination.total_pages; i++) {
+            if (i === pagination.current_page) {
+                paginationHtml += `<strong>${i}</strong> `;
+            } else {
+                paginationHtml += `<a href="#" class="pagination-btn" data-page="${i}">${i}</a> `;
+            }
+        }
+        paginationContainer.innerHTML = paginationHtml;
+    }
+
+
+    // --- Event Listeners ---
+
+    botSelector.addEventListener('change', () => fetchHistory(1));
+
+    methodSelector.addEventListener('change', () => {
+        buildParamsForm(methodSelector.value);
+    });
+
+    apiParamsForm.addEventListener('submit', runApiRequest);
+
+    paginationContainer.addEventListener('click', function(e) {
+        if (e.target.matches('.pagination-btn')) {
+            e.preventDefault();
+            const page = parseInt(e.target.dataset.page, 10);
+            fetchHistory(page);
+        }
+    });
+
+    // --- Inisialisasi ---
+    fetchMethods();
+    if (botSelector.value) {
+        fetchHistory(1);
+    }
+});
+</script>
 
 <?php include __DIR__ . '/partials/footer.php'; ?>

--- a/admin/api_test_handler.php
+++ b/admin/api_test_handler.php
@@ -1,0 +1,129 @@
+<?php
+header('Content-Type: application/json');
+
+require_once __DIR__ . '/../core/database.php';
+require_once __DIR__ . '/../core/helpers.php';
+require_once __DIR__ . '/../core/TelegramAPI.php';
+
+$pdo = get_db_connection();
+if (!$pdo) {
+    echo json_encode(['error' => 'Koneksi database gagal.']);
+    exit;
+}
+
+$action = $_GET['action'] ?? (json_decode(file_get_contents('php://input'), true)['action'] ?? null);
+
+try {
+    switch ($action) {
+        case 'get_methods':
+            handle_get_methods();
+            break;
+        case 'run_method':
+            $data = json_decode(file_get_contents('php://input'), true);
+            handle_run_method($pdo, $data);
+            break;
+        case 'get_history':
+            handle_get_history($pdo, $_GET);
+            break;
+        default:
+            throw new Exception('Aksi tidak valid.');
+    }
+} catch (Exception $e) {
+    http_response_code(400);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+
+function handle_get_methods() {
+    $reflection = new ReflectionClass('TelegramAPI');
+    $public_methods = $reflection->getMethods(ReflectionMethod::IS_PUBLIC);
+
+    $excluded_methods = ['__construct', '__call', 'escapeMarkdown', 'getBotId', 'sendLongMessage'];
+    $methods_data = [];
+
+    foreach ($public_methods as $method) {
+        $methodName = $method->getName();
+        if (in_array($methodName, $excluded_methods) || strpos($methodName, 'handle') === 0 || strpos($methodName, 'apiRequest') === 0) {
+            continue;
+        }
+
+        $params = [];
+        foreach ($method->getParameters() as $param) {
+            $params[$param->getName()] = [
+                'isOptional' => $param->isOptional(),
+            ];
+        }
+        $methods_data[$methodName] = ['parameters' => $params];
+    }
+    ksort($methods_data);
+    echo json_encode($methods_data);
+}
+
+function handle_run_method($pdo, $data) {
+    $bot_id = $data['bot_id'] ?? null;
+    $method = $data['method'] ?? null;
+    $params = $data['params'] ?? [];
+
+    if (!$bot_id || !$method) {
+        throw new Exception("Bot ID dan metode diperlukan.");
+    }
+
+    $stmt = $pdo->prepare("SELECT token FROM bots WHERE id = ?");
+    $stmt->execute([$bot_id]);
+    $bot_token = $stmt->fetchColumn();
+
+    if (!$bot_token) {
+        throw new Exception("Bot tidak ditemukan.");
+    }
+
+    $telegram_api = new TelegramAPI($bot_token, $pdo, $bot_id);
+    $clean_params = array_filter($params, fn($val) => $val !== '' && $val !== null);
+
+    $api_response = call_user_func_array([$telegram_api, $method], $clean_params);
+
+    // Simpan ke log
+    $log_stmt = $pdo->prepare(
+        "INSERT INTO api_request_logs (bot_id, method, request_payload, response_payload) VALUES (?, ?, ?, ?)"
+    );
+    $log_stmt->execute([
+        $bot_id,
+        $method,
+        json_encode($clean_params),
+        json_encode($api_response)
+    ]);
+
+    echo json_encode(['success' => true, 'api_response' => $api_response]);
+}
+
+function handle_get_history($pdo, $query) {
+    $bot_id = $query['bot_id'] ?? null;
+    if (!$bot_id) {
+        throw new Exception("Bot ID diperlukan.");
+    }
+
+    $page = isset($query['page']) ? (int)$query['page'] : 1;
+    $items_per_page = 10;
+    $offset = ($page - 1) * $items_per_page;
+
+    // Hitung total entri
+    $total_stmt = $pdo->prepare("SELECT COUNT(*) FROM api_request_logs WHERE bot_id = ?");
+    $total_stmt->execute([$bot_id]);
+    $total_items = $total_stmt->fetchColumn();
+    $total_pages = ceil($total_items / $items_per_page);
+
+    // Ambil data untuk halaman saat ini
+    $stmt = $pdo->prepare(
+        "SELECT * FROM api_request_logs WHERE bot_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?"
+    );
+    $stmt->execute([$bot_id, $items_per_page, $offset]);
+    $history = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    echo json_encode([
+        'history' => $history,
+        'pagination' => [
+            'current_page' => $page,
+            'total_pages' => (int)$total_pages,
+            'total_items' => (int)$total_items
+        ]
+    ]);
+}
+?>

--- a/config.php
+++ b/config.php
@@ -1,0 +1,20 @@
+<?php
+// Salin file ini ke config.php dan isi nilainya.
+
+// Konfigurasi Database
+define('DB_HOST', 'localhost');
+define('DB_USER', 'tguser');
+define('DB_PASS', 'tgpass');
+define('DB_NAME', 'telegram_dashboard');
+
+// URL dasar aplikasi (akhiri dengan /)
+// Contoh: define('BASE_URL', 'https://mydomain.com/tgbots/');
+define('BASE_URL', '');
+
+// (Opsional) ID Telegram dari admin utama (Super Admin).
+// Pengguna dengan ID ini akan secara otomatis mendapatkan peran 'admin'
+// saat pertama kali berinteraksi dengan bot manapun.
+// Kosongkan jika tidak ingin menggunakan fitur ini.
+define('SUPER_ADMIN_TELEGRAM_ID', '');
+
+?>

--- a/logs/database.log
+++ b/logs/database.log
@@ -1,0 +1,2 @@
+[2025-08-17 11:13:13] Koneksi database gagal: SQLSTATE[HY000] [1698] Access denied for user 'root'@'localhost'
+[2025-08-17 11:14:26] Setup database dari setup.sql berhasil dijalankan.

--- a/logs/error.log
+++ b/logs/error.log
@@ -1,0 +1,1 @@
+[2025-08-17 11:08:52] Error: config.php tidak ditemukan. Harap salin dari config.php.example dan isi kredensialnya.

--- a/migrations/023_create_api_request_logs_table.sql
+++ b/migrations/023_create_api_request_logs_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `api_request_logs` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `bot_id` int(11) NOT NULL,
+  `method` varchar(255) NOT NULL,
+  `request_payload` text,
+  `response_payload` text,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `bot_id` (`bot_id`),
+  CONSTRAINT `api_request_logs_ibfk_1` FOREIGN KEY (`bot_id`) REFERENCES `bots` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;


### PR DESCRIPTION
Ini adalah pembaruan signifikan untuk halaman tes API yang baru ditambahkan. Fitur ini sekarang sepenuhnya didorong oleh AJAX dan mencakup riwayat permintaan.

Perubahan Utama:
- **UI Dropdown & Dinamis:** Daftar metode API sekarang ada di dalam dropdown. Memilih metode akan secara dinamis membuat formulir input parameter menggunakan JavaScript.
- **Permintaan AJAX:** Semua panggilan API sekarang ditangani melalui AJAX, memberikan pengalaman pengguna yang lancar tanpa memuat ulang halaman.
- **Riwayat Permintaan:** Setiap panggilan API yang dibuat melalui antarmuka sekarang dicatat ke tabel database baru `api_request_logs`.
- **Tampilan Riwayat:** Riwayat permintaan ditampilkan di bawah antarmuka pengujian, dengan paginasi untuk 10 item per halaman.
- **Backend Handler:** Skrip `admin/api_test_handler.php` baru dibuat untuk menangani semua permintaan AJAX (mengambil metode, menjalankan metode, mengambil riwayat).
- **Migrasi Database:** Menambahkan file migrasi untuk membuat tabel `api_request_logs`.