### PR TITLE
Feat: Return detailed API errors and fix UI bugs

### DIFF
--- a/core/TelegramAPI.php
+++ b/core/TelegramAPI.php
@@ -87,7 +87,12 @@ class TelegramAPI {
                 curl_close($ch);
             }
             $this->handleApiError($e, $response, $method, $data);
-            return false;
+            // Kembalikan array error yang konsisten dengan format respons Telegram
+            return [
+                'ok' => false,
+                'error_code' => $e->getCode(),
+                'description' => $e->getMessage(),
+            ];
         }
     }
 


### PR DESCRIPTION
- Enhances API error handling in `core/TelegramAPI.php` to return a detailed error array (`ok`, `error_code`, `description`) instead of a simple `false`. This provides better feedback in the API tester.
- Fixes a client-side bug in `admin/api_test.php` that caused 'undefined' to be displayed for nested parameter labels and input placeholders.
- Sets the default `parse_mode` to 'Markdown' for all relevant messaging methods.
- Adds server-side validation for `reply_parameters` to ensure it's a valid, non-empty array before being sent.