### PR TITLE
Fix: Finalize API tester fixes and improvements

### DIFF
--- a/admin/api_test_handler.php
+++ b/admin/api_test_handler.php
@@ -130,6 +130,11 @@ function handle_run_method($pdo, $data) {
         }
     }
 
+    // Lakukan type casting untuk parameter spesifik
+    if (isset($clean_params['message_thread_id']) && is_numeric($clean_params['message_thread_id'])) {
+        $clean_params['message_thread_id'] = (int)$clean_params['message_thread_id'];
+    }
+
     // Re-create the final argument list in the correct order
     $reflection = new ReflectionMethod('TelegramAPI', $method);
     $final_args = [];


### PR DESCRIPTION
This commit includes several fixes and quality-of-life improvements for the API tester and core Telegram API class.

- Casts `message_thread_id` to an integer in the API handler to prevent data type errors.
- Enhances API error handling to return a detailed error object instead of `false`.
- Fixes a client-side UI bug that displayed 'undefined' for nested parameter labels and placeholders.
- Sets the default `parse_mode` to 'Markdown' for all relevant messaging methods.
- Adds server-side validation for the `reply_parameters` object.