### PR TITLE
Fix: Correct dynamic argument handling and improve API tester

### DIFF
--- a/admin/api_test_handler.php
+++ b/admin/api_test_handler.php
@@ -135,7 +135,7 @@ function handle_run_method($pdo, $data) {
         $clean_params['message_thread_id'] = (int)$clean_params['message_thread_id'];
     }
 
-    // Re-create the final argument list in the correct order
+    // Re-create the final argument list in the correct order, handling optional params correctly
     $reflection = new ReflectionMethod('TelegramAPI', $method);
     $final_args = [];
     foreach ($reflection->getParameters() as $param) {
@@ -143,10 +143,12 @@ function handle_run_method($pdo, $data) {
         if (isset($clean_params[$paramName])) {
             $final_args[] = $clean_params[$paramName];
         } else {
-            // This will fail for non-optional params, which is expected.
-            // For optional ones, it will pass `null` implicitly.
-            if (!$param->isOptional()) {
-                 throw new Exception("Parameter wajib '{$paramName}' tidak ada.");
+            if ($param->isOptional()) {
+                // Gunakan nilai default jika parameter opsional tidak disediakan
+                $final_args[] = $param->getDefaultValue();
+            } else {
+                // Lemparkan error jika parameter wajib tidak ada
+                throw new Exception("Parameter wajib '{$paramName}' tidak ada.");
             }
         }
     }


### PR DESCRIPTION
This commit resolves a critical bug in the API test handler that caused incorrect parameter ordering when optional parameters were skipped.

- Rewrites the reflection-based argument building in `handle_run_method` to correctly use default values for omitted optional parameters, ensuring arguments are always passed in the correct position.
- Fixes a client-side UI bug that displayed 'undefined' for nested parameter labels and placeholders.
- Adds type-casting for `message_thread_id` to ensure it is an integer.
- Enhances API error handling to return a detailed error object instead of `false`.
- Sets the default `parse_mode` to 'Markdown' for all relevant messaging methods.