### PR TITLE
feat: Implement discussion group replies for channel posts

### DIFF
--- a/core/handlers/CallbackQueryHandler.php
+++ b/core/handlers/CallbackQueryHandler.php
@@ -68,15 +68,7 @@ class CallbackQueryHandler
         }
         $channel_id = $sales_channel['channel_id'];
 
-        // 3. Get full channel info to check for a linked discussion group
-        $channel_info = $this->telegram_api->getChat($channel_id);
-        if (!$channel_info || ($channel_info['ok'] === false)) {
-            $this->telegram_api->answerCallbackQuery($callback_query_id, '⚠️ Gagal mendapatkan informasi channel. Pastikan bot masih menjadi admin.', true);
-            return;
-        }
-        $linked_chat_id = $channel_info['result']['linked_chat_id'] ?? null;
-
-        // 4. Get thumbnail to post
+        // 3. Get thumbnail to post
         $thumbnail = $this->package_repo->getThumbnailFile($package['id']);
         if (!$thumbnail) {
             $this->telegram_api->answerCallbackQuery($callback_query_id, '⚠️ Gagal mendapatkan media pratinjau untuk konten ini.', true);
@@ -96,59 +88,36 @@ class CallbackQueryHandler
         $keyboard = ['inline_keyboard' => [[['text' => "Beli Sekarang 🛒", 'url' => $buy_url]]]];
         $reply_markup = json_encode($keyboard);
 
-        // 5. Try to post based on whether a discussion group is linked
+        // 5. Post to the channel
         try {
-            if ($linked_chat_id) {
-                // Case A: Discussion group exists. Post to channel, then post to the discussion thread.
-                $channel_post_result = $this->telegram_api->copyMessage(
-                    $channel_id,
-                    $thumbnail['chat_id'],
-                    $thumbnail['message_id'],
-                    $caption,
-                    'Markdown',
-                    null, // No keyboard in the channel post
-                    (bool)$package['protect_content']
-                );
+            $result = $this->telegram_api->copyMessage(
+                $channel_id,
+                $thumbnail['chat_id'],
+                $thumbnail['message_id'],
+                $caption,
+                'Markdown',
+                $reply_markup,
+                (bool)$package['protect_content']
+            );
 
-                if (!$channel_post_result || ($channel_post_result['ok'] === false)) {
-                    throw new Exception($channel_post_result['description'] ?? 'Gagal mengirim pesan ke channel.');
+            if (!$result || ($result['ok'] === false)) {
+                // Check for a specific error message indicating the bot was kicked or permissions were lost
+                $error_description = $result['description'] ?? '';
+                if (stripos($error_description, 'bot was kicked') !== false || stripos($error_description, 'not a member') !== false) {
+                    // If bot is kicked, deactivate the channel to prevent further attempts
+                    $this->sales_channel_repo->deactivate($internal_user_id);
+                    $error_message = "❌ Gagal: Bot bukan lagi admin di channel. Channel Anda telah di-unregister secara otomatis.";
+                    $this->telegram_api->answerCallbackQuery($callback_query_id, $error_message, true);
+                    app_log("Deactivating channel {$channel_id} for user {$internal_user_id} due to being kicked.", 'bot_error');
+                    return;
                 }
-
-                // The message_id of the post in the channel becomes the message_thread_id for the discussion group
-                $message_thread_id = $channel_post_result['result']['message_id'];
-
-                // Send a new message with the keyboard to the discussion group's topic
-                $this->telegram_api->sendMessage(
-                    $linked_chat_id,
-                    "⬇️ Tombol aksi untuk postingan di atas ⬇️",
-                    'Markdown',
-                    $reply_markup,
-                    $message_thread_id
-                );
-
-            } else {
-                // Case B: No discussion group. Post to channel with keyboard (original behavior).
-                $result = $this->telegram_api->copyMessage(
-                    $channel_id,
-                    $thumbnail['chat_id'],
-                    $thumbnail['message_id'],
-                    $caption,
-                    'Markdown',
-                    $reply_markup,
-                    (bool)$package['protect_content']
-                );
-
-                if (!$result || ($result['ok'] === false)) {
-                    throw new Exception($result['description'] ?? 'Gagal mengirim pesan ke channel.');
-                }
+                throw new Exception($error_description);
             }
 
             $this->telegram_api->answerCallbackQuery($callback_query_id, '✅ Berhasil di-posting!', false);
 
         } catch (Exception $e) {
-            // Un-register the channel on failure
-            $this->sales_channel_repo->deactivate($internal_user_id);
-            $error_message = "❌ Gagal mem-posting. Pastikan bot adalah admin di channel & grup diskusi. Channel Anda telah di-unregister secara otomatis.";
+            $error_message = "❌ Gagal mem-posting ke channel. Pastikan bot adalah admin dan memiliki izin yang benar.";
             $this->telegram_api->answerCallbackQuery($callback_query_id, $error_message, true);
             app_log("Gagal post ke channel {$channel_id} untuk user {$internal_user_id}: " . $e->getMessage(), 'bot_error');
         }


### PR DESCRIPTION
This commit implements the feature to have the bot reply to automatically forwarded channel posts in a linked discussion group.

- `CallbackQueryHandler.php` is simplified to always post a message with a "Buy" URL button to the sales channel. This allows Telegram's native `is_automatic_forward` functionality to work.

- `MessageHandler.php` now contains logic to detect these automatically forwarded messages. When one is detected, the bot extracts the product's public ID from the button URL.

- The bot then sends a new message to the discussion group, replying directly to the forwarded post. This reply contains a "Buy" button with a `callback_data` payload for a better user experience inside the group.

This implementation correctly follows the user's specified workflow. This commit also preserves the fixes for previously identified Markdown escaping bugs.