### PR TITLE
feat: Implement DB-driven replies in discussion groups

### DIFF
--- a/core/database/ChannelPostPackageRepository.php
+++ b/core/database/ChannelPostPackageRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+class ChannelPostPackageRepository
+{
+    private $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * Creates a new record to link a channel post to a package.
+     *
+     * @param int $channel_id The ID of the channel.
+     * @param int $message_id The ID of the message in the channel.
+     * @param int $package_id The ID of the package.
+     * @return bool True on success, false on failure.
+     */
+    public function create(int $channel_id, int $message_id, int $package_id): bool
+    {
+        $sql = "INSERT INTO channel_post_packages (channel_id, message_id, package_id) VALUES (?, ?, ?)";
+        try {
+            $stmt = $this->pdo->prepare($sql);
+            return $stmt->execute([$channel_id, $message_id, $package_id]);
+        } catch (PDOException $e) {
+            // Log error
+            app_log("Error creating channel post package link: " . $e->getMessage(), 'error');
+            return false;
+        }
+    }
+
+    /**
+     * Finds a package ID by the channel and message ID.
+     *
+     * @param int $channel_id The ID of the channel.
+     * @param int $message_id The ID of the message in the channel.
+     * @return array|null The package record or null if not found.
+     */
+    public function findByChannelAndMessage(int $channel_id, int $message_id): ?array
+    {
+        $sql = "SELECT p.* FROM media_packages p
+                JOIN channel_post_packages cpp ON p.id = cpp.package_id
+                WHERE cpp.channel_id = ? AND cpp.message_id = ?";
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute([$channel_id, $message_id]);
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $result ?: null;
+    }
+}

--- a/migrations/024_create_channel_post_packages_table.sql
+++ b/migrations/024_create_channel_post_packages_table.sql
@@ -1,0 +1,13 @@
+-- Migration to create a table linking channel posts to media packages
+
+CREATE TABLE `channel_post_packages` (
+    `id` INT(11) NOT NULL AUTO_INCREMENT,
+    `channel_id` BIGINT NOT NULL,
+    `message_id` BIGINT NOT NULL,
+    `package_id` INT(11) NOT NULL,
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `channel_message_idx` (`channel_id`, `message_id`),
+    KEY `package_id_fk_idx` (`package_id`),
+    CONSTRAINT `channel_post_packages_package_id_fk` FOREIGN KEY (`package_id`) REFERENCES `media_packages` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
This commit implements a new, robust workflow for handling channel posts in linked discussion groups, based on user feedback.

When a seller posts content to a channel, the bot now performs the following actions:
1.  Posts the message to the channel WITHOUT any inline buttons.
2.  Retrieves the message_id of the new channel post.
3.  Saves a mapping of (channel_id, message_id) -> package_id in a new `channel_post_packages` database table.

When this message is automatically forwarded by Telegram to the linked discussion group, the `MessageHandler` detects it via the `is_automatic_forward` flag. It then:
1.  Uses the `forward_from_chat` and `forward_from_message_id` fields to look up the corresponding package_id in the new database table.
2.  If a match is found, it sends a reply to the forwarded message in the discussion group, containing the 'Buy' button with the correct package information.

This approach satisfies the requirement of not having a 'Buy' button on the initial channel post, while still enabling the reply feature in the discussion group.

This commit includes the new database migration, the repository for the new table, and the necessary logic changes in the callback and message handlers. It also preserves previous bug fixes for Markdown escaping.