### PR TITLE
feat: Implement DB-driven replies in discussion groups

### DIFF
--- a/migrations/024_create_channel_post_packages_table.sql
+++ b/migrations/024_create_channel_post_packages_table.sql
@@ -4,7 +4,7 @@ CREATE TABLE `channel_post_packages` (
     `id` INT(11) NOT NULL AUTO_INCREMENT,
     `channel_id` BIGINT NOT NULL,
     `message_id` BIGINT NOT NULL,
-    `package_id` INT(11) NOT NULL,
+    `package_id` BIGINT NOT NULL,
     `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (`id`),
     UNIQUE KEY `channel_message_idx` (`channel_id`, `message_id`),


### PR DESCRIPTION
This commit implements a new, robust workflow for handling channel posts in linked discussion groups, based on user feedback. This version supersedes previous attempts.

When a seller posts content to a channel, the bot now performs the following actions:
1.  Posts the message to the channel WITHOUT any inline buttons.
2.  Retrieves the message_id of the new channel post.
3.  Saves a mapping of (channel_id, message_id) -> package_id in a new `channel_post_packages` database table.

When this message is automatically forwarded by Telegram to the linked discussion group, the `MessageHandler` detects it via the `is_automatic_forward` flag. It then:
1.  Uses the `forward_from_chat` and `forward_from_message_id` fields to look up the corresponding package_id in the new database table.
2.  If a match is found, it sends a reply to the forwarded message in the discussion group, containing the 'Buy' button with the correct package information.

This approach satisfies the requirement of not having a 'Buy' button on the initial channel post, while still enabling the reply feature in the discussion group.

This commit includes the new database migration (with corrected data types), the repository for the new table, and the necessary logic changes in the callback and message handlers. It also preserves previous bug fixes for Markdown escaping.