### PR TITLE
feat: Implement DB-driven discussion replies and full debug system

### DIFF
--- a/admin/logs.php
+++ b/admin/logs.php
@@ -1,89 +1,139 @@
 <?php
-session_start();
-require_once __DIR__ . '/../core/helpers.php'; // For app_log
+// admin/logs.php
+
+// Define ROOT_PATH for reliable file access
+if (!defined('ROOT_PATH')) {
+    define('ROOT_PATH', dirname(__DIR__));
+}
+
+require_once ROOT_PATH . '/core/database.php';
+require_once ROOT_PATH . '/core/helpers.php';
 
 // --- Konfigurasi ---
-$log_dir = __DIR__ . '/../logs';
-$lines_to_show = 20;
+$pdo = get_db_connection();
+$lines_to_show = 100; // Jumlah log yang ditampilkan per halaman
 
-// --- Dapatkan daftar file log ---
-$log_files = glob($log_dir . '/*.log');
-$log_names = array_map(function($file) {
-    return basename($file, '.log');
-}, $log_files);
+// --- Dapatkan Level Log yang Tersedia ---
+$stmt_levels = $pdo->query("SELECT DISTINCT level FROM app_logs ORDER BY level ASC");
+$log_levels = $stmt_levels->fetchAll(PDO::FETCH_COLUMN);
 
-// --- Tentukan log yang akan ditampilkan ---
-$selected_log = isset($_GET['log']) && in_array($_GET['log'], $log_names) ? $_GET['log'] : ($log_names[0] ?? null);
+// --- Tentukan Filter ---
+$selected_level = isset($_GET['level']) && in_array($_GET['level'], $log_levels) ? $_GET['level'] : 'all';
 
 // --- Handle Aksi ---
 $message = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
-    if ($_POST['action'] === 'clear_log' && $selected_log) {
-        $file_to_clear = $log_dir . '/' . $selected_log . '.log';
-        if (file_exists($file_to_clear)) {
-            file_put_contents($file_to_clear, '');
-            app_log("Log file '{$selected_log}.log' dibersihkan oleh admin.", 'app');
-            $message = "Log '{$selected_log}' berhasil dibersihkan.";
+    if ($_POST['action'] === 'clear_logs') {
+        try {
+            $pdo->query("TRUNCATE TABLE app_logs");
+            app_log("Tabel app_logs dibersihkan oleh admin.", 'system');
+            $message = "Semua log berhasil dibersihkan.";
+            // Redirect to avoid re-posting on refresh
+            header("Location: logs.php?message=" . urlencode($message));
+            exit;
+        } catch (PDOException $e) {
+            $message = "Gagal membersihkan log: " . $e->getMessage();
         }
     }
 }
 
-// --- Baca isi log ---
-$log_content = [];
-if ($selected_log) {
-    $log_file_path = $log_dir . '/' . $selected_log . '.log';
-    if (file_exists($log_file_path) && filesize($log_file_path) > 0) {
-        // Baca semua baris
-        $lines = file($log_file_path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        // Ambil N baris terakhir
-        $log_content = array_slice($lines, -$lines_to_show);
-        // Urutkan dari yang terbaru
-        $log_content = array_reverse($log_content);
-    }
+if (isset($_GET['message'])) {
+    $message = htmlspecialchars($_GET['message']);
 }
 
-$page_title = 'Log Viewer';
-require_once __DIR__ . '/../partials/header.php';
+
+// --- Baca isi log dari DB ---
+$sql = "SELECT * FROM app_logs";
+if ($selected_level !== 'all') {
+    $sql .= " WHERE level = :level";
+}
+$sql .= " ORDER BY id DESC LIMIT :limit";
+
+$stmt = $pdo->prepare($sql);
+
+if ($selected_level !== 'all') {
+    $stmt->bindParam(':level', $selected_level, PDO::PARAM_STR);
+}
+$stmt->bindParam(':limit', $lines_to_show, PDO::PARAM_INT);
+$stmt->execute();
+$logs = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+$page_title = 'Database Log Viewer';
+include_once ROOT_PATH . '/partials/header.php';
 ?>
 
-<h1>Log Viewer</h1>
+<div class="container mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4"><?php echo $page_title; ?></h1>
 
-        <?php if ($message): ?>
-    <div class="alert alert-success"><?= htmlspecialchars($message) ?></div>
-        <?php endif; ?>
+    <?php if ($message): ?>
+        <div class="alert alert-success"><?= $message ?></div>
+    <?php endif; ?>
 
-        <div class="log-controls">
-    <form action="logs.php" method="get" class="form-inline">
-                <label for="log_select">Pilih Log:</label>
-                <select name="log" id="log_select" onchange="this.form.submit()">
-                    <?php foreach ($log_names as $name): ?>
-                        <option value="<?= $name ?>" <?= ($selected_log === $name) ? 'selected' : '' ?>>
-                            <?= ucfirst($name) ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            </form>
-            <div>
-                <a href="logs.php?log=<?= $selected_log ?>" class="btn">Refresh</a>
-                <?php if ($selected_log): ?>
-                <form action="logs.php?log=<?= $selected_log ?>" method="post" style="display:inline;" onsubmit="return confirm('Anda yakin ingin membersihkan log ini? Aksi ini tidak dapat diurungkan.');">
-                    <input type="hidden" name="action" value="clear_log">
-                    <button type="submit" class="btn btn-danger">Bersihkan Log</button>
-                </form>
-                <?php endif; ?>
-            </div>
-        </div>
-
-        <div class="log-viewer">
-            <?php if (empty($log_content)): ?>
-        <p class="empty">Log ini kosong atau tidak dapat diakses.</p>
-            <?php else: ?>
-                <?php foreach ($log_content as $line): ?>
-                    <p><?= htmlspecialchars($line) ?></p>
+    <div class="flex justify-between items-center mb-4">
+        <form action="logs.php" method="get" class="flex items-center space-x-2">
+            <label for="level_select">Filter by Level:</label>
+            <select name="level" id="level_select" onchange="this.form.submit()" class="p-2 border rounded-md">
+                <option value="all" <?= ($selected_level === 'all') ? 'selected' : '' ?>>All Levels</option>
+                <?php foreach ($log_levels as $level): ?>
+                    <option value="<?= htmlspecialchars($level) ?>" <?= ($selected_level === $level) ? 'selected' : '' ?>>
+                        <?= ucfirst(htmlspecialchars($level)) ?>
+                    </option>
                 <?php endforeach; ?>
-            <?php endif; ?>
+            </select>
+        </form>
+        <div>
+            <a href="logs.php?level=<?= $selected_level ?>" class="btn">Refresh</a>
+            <form action="logs.php" method="post" style="display:inline;" onsubmit="return confirm('Anda yakin ingin MENGHAPUS SEMUA log? Aksi ini tidak dapat diurungkan.');">
+                <input type="hidden" name="action" value="clear_logs">
+                <button type="submit" class="btn btn-danger">Clear All Logs</button>
+            </form>
         </div>
+    </div>
+
+    <div class="overflow-x-auto bg-white shadow-md rounded-lg">
+        <table class="min-w-full">
+            <thead class="bg-gray-200">
+                <tr>
+                    <th class="px-4 py-2">ID</th>
+                    <th class="px-4 py-2">Timestamp</th>
+                    <th class="px-4 py-2">Level</th>
+                    <th class="px-4 py-2">Message</th>
+                    <th class="px-4 py-2">Context</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php if (empty($logs)): ?>
+                    <tr>
+                        <td colspan="5" class="text-center py-4">No logs found.</td>
+                    </tr>
+                <?php else: ?>
+                    <?php foreach ($logs as $log): ?>
+                        <tr class="border-b">
+                            <td class="px-4 py-2"><?= htmlspecialchars($log['id']) ?></td>
+                            <td class="px-4 py-2 whitespace-nowrap"><?= htmlspecialchars($log['created_at']) ?></td>
+                            <td class="px-4 py-2">
+                                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full
+                                    <?= ($log['level'] == 'error' ? 'bg-red-100 text-red-800' : ($log['level'] == 'debug' ? 'bg-blue-100 text-blue-800' : 'bg-green-100 text-green-800')) ?>">
+                                    <?= htmlspecialchars($log['level']) ?>
+                                </span>
+                            </td>
+                            <td class="px-4 py-2"><?= htmlspecialchars($log['message']) ?></td>
+                            <td class="px-4 py-2">
+                                <?php if (!empty($log['context'])): ?>
+                                    <pre class="bg-gray-100 p-2 rounded-md text-xs"><code><?php
+                                        $context_data = json_decode($log['context']);
+                                        echo htmlspecialchars(json_encode($context_data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+                                    ?></code></pre>
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+            </tbody>
+        </table>
+    </div>
+</div>
 
 <?php
-require_once __DIR__ . '/../partials/footer.php';
+include_once ROOT_PATH . '/partials/footer.php';
 ?>

--- a/migrations/026_create_app_logs_table.sql
+++ b/migrations/026_create_app_logs_table.sql
@@ -1,0 +1,9 @@
+-- Migration to create a table for database-driven application logging
+
+CREATE TABLE `app_logs` (
+    `id` BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `level` VARCHAR(20) NOT NULL,
+    `message` TEXT NOT NULL,
+    `context` JSON NULL,
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
This commit delivers a complete solution for handling discussion group replies and adds comprehensive debugging and logging tools as per user requests.

Core Feature: DB-Driven Discussion Group Replies
- When posting to a channel, the bot now sends the message without a 'Buy' button and stores a mapping (channel_id, message_id -> package_id) in a new `channel_post_packages` table.
- A new handler in `MessageHandler` detects automatically forwarded posts in the discussion group, looks up the package from the database, and sends a reply with the 'Buy' button.

Supporting Features:
1.  Raw Update Debug Feed:
    - A new `raw_updates` table logs every incoming JSON payload from Telegram before any processing.
    - A new `admin/debug_feed.php` page displays these raw payloads, providing complete visibility into incoming data.

2.  Database-Driven Logging:
    - The application's logging system has been refactored.
    - A new `app_logs` table now stores all application logs.
    - The `app_log()` helper function now writes to the database instead of a file.
    - The `admin/logs.php` page has been rewritten to be a powerful, filterable viewer for these database logs.

This comprehensive set of changes provides the requested functionality and robust tools for monitoring and debugging the application.