### PR TITLE
Fix: Kirim `reply_parameters` sebagai array, bukan string

### DIFF
--- a/core/handlers/MessageHandler.php
+++ b/core/handlers/MessageHandler.php
@@ -648,7 +648,7 @@ EOT;
         $reply_markup = json_encode($keyboard);
 
         // Siapkan parameter balasan untuk membalas pesan yang diteruskan di grup diskusi.
-        $reply_parameters = json_encode(['message_id' => $this->message['message_id']]);
+        $reply_parameters = ['message_id' => $this->message['message_id']];
 
         // Teks balasan seperti yang ditentukan dalam UPDATE.md.
         $reply_text = "Klik tombol di bawah untuk membeli";


### PR DESCRIPTION
Memperbaiki bug di `MessageHandler` di mana `reply_parameters` di-encode menjadi JSON secara manual. Ini menyebabkan parameter diabaikan oleh `TelegramAPI::sendMessage` karena gagal dalam pengecekan `is_array()`.

Dengan menghapus `json_encode`, parameter sekarang dikirim dengan benar sebagai array, yang memungkinkan bot untuk mengirim pesan sebagai balasan (reply) sesuai harapan.