### PR TITLE
Fix: Perbaiki TypeError di kode logging MessageHandler

### DIFF
--- a/core/handlers/MessageHandler.php
+++ b/core/handlers/MessageHandler.php
@@ -658,7 +658,7 @@ EOT;
             'chat_id' => $this->chat_id,
             'text' => $reply_text,
             'reply_markup' => json_decode($reply_markup),
-            'reply_parameters' => json_decode($reply_parameters)
+            'reply_parameters' => $reply_parameters
         ];
         app_log("[TRACE] Mencoba mengirim balasan. Detail: " . json_encode($log_details), 'trace');
         $this->telegram_api->sendMessage(


### PR DESCRIPTION
Menghapus pemanggilan `json_decode()` yang salah pada `$reply_parameters` di dalam blok logging di `handleAutomaticForward`.

Variabel ini sudah dalam format array, dan memanggil `json_decode()` padanya menyebabkan `TypeError`. Perbaikan ini memastikan logging berjalan tanpa error.