### PR TITLE
fix: Constrain chart container height to prevent infinite growth

### DIFF
--- a/partials/header.php
+++ b/partials/header.php
@@ -73,6 +73,8 @@ $is_admin_page = strpos($_SERVER['PHP_SELF'], '/admin/') !== false;
             padding: 20px;
             border-radius: 8px;
             box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+            position: relative;
+            height: 400px;
         }
         .list-table {
             width: 100%;


### PR DESCRIPTION
This commit fixes a rendering bug where the sales chart's height would grow uncontrollably. By setting a fixed height and relative position on the chart's container, the Chart.js canvas now renders correctly within its designated area.