### PR TITLE
feat: Display content ID in top selling items table

### DIFF
--- a/member/dashboard.php
+++ b/member/dashboard.php
@@ -159,6 +159,7 @@ require_once __DIR__ . '/../partials/header.php';
             <table class="list-table">
                 <thead>
                     <tr>
+                        <th>ID</th>
                         <th>Deskripsi Konten</th>
                         <th>Jumlah Terjual</th>
                         <th>Total Pendapatan</th>
@@ -167,6 +168,7 @@ require_once __DIR__ . '/../partials/header.php';
                 <tbody>
                     <?php foreach ($top_selling_items as $item): ?>
                         <tr>
+                            <td><?= htmlspecialchars($item['id']) ?></td>
                             <td><?= htmlspecialchars($item['description']) ?></td>
                             <td><?= number_format($item['sales_count']) ?></td>
                             <td>Rp <?= number_format($item['total_revenue'], 0, ',', '.') ?></td>


### PR DESCRIPTION
This commit updates the 'Top 5 Selling Content' table on the member dashboard to include a column for the content ID. This makes it easier for sellers to identify their top-performing items.