### PR TITLE
fix: Redirect GET requests on package_manager.php

### DIFF
--- a/member/package_manager.php
+++ b/member/package_manager.php
@@ -14,6 +14,13 @@
  * 4. Kembalikan respons JSON yang berisi status operasi dan status proteksi baru.
  */
 session_start();
+
+// Jika diakses langsung (GET), redirect ke halaman yang lebih sesuai
+if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+    header("Location: sold.php");
+    exit;
+}
+
 header('Content-Type: application/json');
 
 // Respon default jika terjadi error


### PR DESCRIPTION
The script at 'member/package_manager.php' is a backend handler for POST requests and was showing a JSON error when accessed directly via GET. This commit adds a redirect so that any user who navigates to the URL directly is sent to 'sold.php' instead of seeing an unhelpful error message.