### PR TITLE
feat: Implement edit functionality for packages

### DIFF
--- a/core/database/PackageRepository.php
+++ b/core/database/PackageRepository.php
@@ -281,6 +281,34 @@ class PackageRepository
     }
 
     /**
+     * Memperbarui detail sebuah paket (deskripsi dan harga).
+     *
+     * @param int $packageId ID paket yang akan diperbarui.
+     * @param int $sellerId ID penjual yang meminta, untuk verifikasi kepemilikan.
+     * @param string $description Deskripsi baru untuk paket.
+     * @param int|null $price Harga baru untuk paket (bisa null jika tidak diubah).
+     * @return bool True jika berhasil, false jika gagal.
+     * @throws Exception Jika paket tidak ditemukan atau pengguna bukan pemiliknya.
+     */
+    public function updatePackageDetails(int $packageId, int $sellerId, string $description, ?int $price): bool
+    {
+        $package = $this->find($packageId);
+
+        if (!$package) {
+            throw new Exception("Paket tidak ditemukan.");
+        }
+
+        if ($package['seller_user_id'] != $sellerId) {
+            throw new Exception("Anda tidak memiliki izin untuk mengubah paket ini.");
+        }
+
+        $stmt = $this->pdo->prepare(
+            "UPDATE media_packages SET description = ?, price = ? WHERE id = ?"
+        );
+        return $stmt->execute([$description, $price, $packageId]);
+    }
+
+    /**
      * Membuat paket baru dengan ID publik yang unik dan diformat secara otomatis.
      * Metode ini secara atomik menaikkan nomor urut paket penjual dan membuat ID.
      * Sebaiknya dijalankan di dalam sebuah transaksi.

--- a/member/edit_package.php
+++ b/member/edit_package.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Halaman untuk Mengedit Paket Konten.
+ *
+ * Halaman ini menangani dua hal:
+ * 1. Menampilkan form untuk mengedit detail paket (deskripsi, harga) saat diakses dengan metode GET.
+ * 2. Memproses data dari form tersebut saat dikirim dengan metode POST.
+ */
+session_start();
+
+// Jika belum login, redirect ke halaman login
+if (!isset($_SESSION['member_user_id'])) {
+    header("Location: index.php");
+    exit;
+}
+
+require_once __DIR__ . '/../core/database.php';
+require_once __DIR__ . '/../core/database/PackageRepository.php';
+
+$pdo = get_db_connection();
+$packageRepo = new PackageRepository($pdo);
+$user_id = $_SESSION['member_user_id'];
+$error_message = null;
+$success_message = null;
+
+// Ambil ID paket dari URL
+$package_id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+if (!$package_id) {
+    header("Location: my_content.php"); // Redirect jika ID tidak valid
+    exit;
+}
+
+// Ambil data paket untuk memastikan pemiliknya adalah pengguna yang sedang login
+try {
+    $package = $packageRepo->find($package_id);
+    if (!$package || $package['seller_user_id'] != $user_id) {
+        // Jika paket tidak ada atau bukan milik user, redirect
+        $_SESSION['flash_message'] = "Error: Paket tidak ditemukan atau Anda tidak memiliki izin.";
+        header("Location: my_content.php");
+        exit;
+    }
+} catch (Exception $e) {
+    $_SESSION['flash_message'] = "Error: " . $e->getMessage();
+    header("Location: my_content.php");
+    exit;
+}
+
+// Handle POST request (form submission)
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $description = trim($_POST['description'] ?? '');
+    // Harga bisa jadi null jika tidak diisi, repository menangani ini
+    $price = !empty($_POST['price']) ? filter_input(INPUT_POST, 'price', FILTER_VALIDATE_INT) : null;
+
+    if (empty($description)) {
+        $error_message = "Deskripsi tidak boleh kosong.";
+    } else {
+        try {
+            $result = $packageRepo->updatePackageDetails($package_id, $user_id, $description, $price);
+            if ($result) {
+                $_SESSION['flash_message'] = "Paket '" . htmlspecialchars($package['public_id']) . "' berhasil diperbarui.";
+                header("Location: my_content.php");
+                exit;
+            } else {
+                $error_message = "Gagal memperbarui paket. Silakan coba lagi.";
+            }
+        } catch (Exception $e) {
+            $error_message = "Terjadi error: " . $e->getMessage();
+        }
+    }
+}
+
+$page_title = 'Edit Konten: ' . htmlspecialchars($package['public_id']);
+require_once __DIR__ . '/../partials/header.php';
+?>
+
+<h2>Edit Konten: <?= htmlspecialchars($package['public_id']) ?></h2>
+<p>Gunakan form di bawah ini untuk mengubah detail konten Anda.</p>
+
+<?php if ($error_message): ?>
+    <div class="alert alert-danger"><?= $error_message ?></div>
+<?php endif; ?>
+
+<form action="edit_package.php?id=<?= $package_id ?>" method="POST">
+    <div style="margin-bottom: 15px;">
+        <label for="description"><strong>Deskripsi</strong></label>
+        <textarea id="description" name="description" rows="4" required><?= htmlspecialchars($package['description']) ?></textarea>
+    </div>
+    <div style="margin-bottom: 15px;">
+        <label for="price"><strong>Harga (Rp)</strong></label>
+        <input type="number" id="price" name="price" value="<?= htmlspecialchars($package['price']) ?>" placeholder="Kosongkan jika tidak ingin dijual">
+    </div>
+
+    <div>
+        <button type="submit" class="btn">Simpan Perubahan</button>
+        <a href="my_content.php" class="btn" style="background-color: #6c757d;">Batal</a>
+    </div>
+</form>
+
+<?php
+require_once __DIR__ . '/../partials/footer.php';
+?>

--- a/member/my_content.php
+++ b/member/my_content.php
@@ -56,7 +56,7 @@ require_once __DIR__ . '/../partials/header.php';
                         <td><span class="status-badge status-<?= htmlspecialchars($package['status']) ?>"><?= ucfirst(htmlspecialchars($package['status'])) ?></span></td>
                         <td><?= htmlspecialchars(date('d M Y H:i', strtotime($package['created_at']))) ?></td>
                         <td>
-                            <a href="#" class="btn btn-edit btn-sm">Edit</a>
+                            <a href="edit_package.php?id=<?= $package['id'] ?>" class="btn btn-edit btn-sm">Edit</a>
                             <a href="#" class="btn btn-delete btn-sm">Hapus</a>
                         </td>
                     </tr>


### PR DESCRIPTION
This commit builds on the 'My Content' page by adding the functionality for the 'Edit' button.

Key changes:
- Adds an 'updatePackageDetails' method to PackageRepository to handle database updates.
- Creates a new 'member/edit_package.php' page with a form to edit package description and price.
- The new page handles both displaying the form (GET) and processing the update (POST).
- The 'Edit' button on the 'my_content.php' page now links to the new edit page.