### PR TITLE
fix: Replace deprecated FILTER_SANITIZE_STRING

### DIFF
--- a/member/edit_package.php
+++ b/member/edit_package.php
@@ -26,7 +26,7 @@ $error_message = null;
 $success_message = null;
 
 // Ambil ID publik paket dari URL
-$public_id = filter_input(INPUT_GET, 'id', FILTER_SANITIZE_STRING);
+$public_id = $_GET['id'] ?? null;
 if (!$public_id) {
     header("Location: my_content.php"); // Redirect jika ID tidak valid
     exit;


### PR DESCRIPTION
This commit resolves a deprecation warning in PHP 8.1+ by replacing the use of the deprecated `FILTER_SANITIZE_STRING` constant in `member/edit_package.php` with a direct `$_GET` access. The input is already being handled safely by prepared statements for database queries and `htmlspecialchars` for output.