### PR TITLE
feat: Add sales trend chart to package detail page

### DIFF
--- a/core/database/AnalyticsRepository.php
+++ b/core/database/AnalyticsRepository.php
@@ -73,9 +73,10 @@ class AnalyticsRepository
      *
      * @param int|null $sellerId Jika null, ambil data global. Jika diisi, filter berdasarkan ID penjual.
      * @param int $days Jumlah hari terakhir yang akan diambil datanya.
+     * @param int|null $packageId Jika diisi, filter berdasarkan ID paket.
      * @return array Daftar data, masing-masing berisi `sales_date` dan `daily_revenue`.
      */
-    public function getSalesByDay(int $sellerId = null, int $days = 30): array
+    public function getSalesByDay(int $sellerId = null, int $days = 30, int $packageId = null): array
     {
         $params = [date('Y-m-d H:i:s', strtotime("-{$days} days"))];
 
@@ -93,6 +94,11 @@ class AnalyticsRepository
         if ($sellerId !== null) {
             $sql .= " AND seller_user_id = ?";
             $params[] = $sellerId;
+        }
+
+        if ($packageId !== null) {
+            $sql .= " AND package_id = ?";
+            $params[] = $packageId;
         }
 
         $sql .= " GROUP BY sales_date ORDER BY sales_date ASC";


### PR DESCRIPTION
This commit replaces the '10 Recent Sales' table on the package detail page with a dynamic sales trend chart.

Key changes:
- The 'getSalesByDay' method in 'AnalyticsRepository' was updated to allow filtering by a specific package ID.
- The 'member/view_package.php' page now displays a Chart.js line chart showing sales revenue over time for the specific package.
- A time range selector has been added to the chart, allowing users to view trends for 7, 30, 90, or 365 days.