### PR TITLE
feat: Display connected bot on channel management page

### DIFF
--- a/core/helpers.php
+++ b/core/helpers.php
@@ -149,3 +149,18 @@ function get_bot_token(PDO $pdo, int $bot_id): ?string
     $token = $stmt->fetchColumn();
     return $token ?: null;
 }
+
+/**
+ * Mendapatkan detail lengkap sebuah bot berdasarkan ID-nya.
+ *
+ * @param PDO $pdo Objek koneksi PDO.
+ * @param int $bot_id ID bot.
+ * @return array|null Detail bot sebagai array asosiatif, atau null jika tidak ditemukan.
+ */
+function get_bot_details(PDO $pdo, int $bot_id): ?array
+{
+    $stmt = $pdo->prepare("SELECT * FROM bots WHERE id = ?");
+    $stmt->execute([$bot_id]);
+    $result = $stmt->fetch(PDO::FETCH_ASSOC);
+    return $result ?: null;
+}

--- a/member/channels.php
+++ b/member/channels.php
@@ -27,12 +27,17 @@ $success_message = null;
 // Ambil bot_id dari session atau dari sumber lain jika tersedia
 // Untuk saat ini, kita asumsikan ada bot default atau bot pertama yang terdaftar
 // Ini mungkin perlu disesuaikan tergantung pada logika aplikasi yang lebih luas
+$bot_details = null;
 try {
     $default_bot_id = get_default_bot_id($pdo);
     if (!$default_bot_id) {
         throw new Exception("Tidak ada bot yang terkonfigurasi di sistem.");
     }
-    $telegram_api = new TelegramAPI(get_bot_token($pdo, $default_bot_id));
+    $bot_details = get_bot_details($pdo, $default_bot_id);
+    if (!$bot_details || !isset($bot_details['token'])) {
+        throw new Exception("Gagal mengambil detail atau token untuk bot default.");
+    }
+    $telegram_api = new TelegramAPI($bot_details['token']);
 } catch (Exception $e) {
     $error_message = "Error inisialisasi sistem: " . $e->getMessage();
 }
@@ -128,6 +133,9 @@ require_once __DIR__ . '/../partials/header.php';
             <strong>ID Channel:</strong> <code><?= htmlspecialchars($current_channel['channel_id']) ?></code><br>
             <?php if ($current_channel['username']): ?>
                 <strong>Username:</strong> @<?= htmlspecialchars($current_channel['username']) ?><br>
+            <?php endif; ?>
+            <?php if ($bot_details && isset($bot_details['username'])): ?>
+                <strong>Terhubung dengan Bot:</strong> @<?= htmlspecialchars($bot_details['username']) ?><br>
             <?php endif; ?>
             <strong>Status:</strong> <span style="color: green; font-weight: bold;">Aktif</span>
         </p>


### PR DESCRIPTION
This commit enhances the 'Channel Management' page by displaying which bot is connected to the user's registered channel.

Key changes:
- Adds a new 'get_bot_details' helper function to fetch bot information.
- Updates 'member/channels.php' to use this function and display the bot's username in the 'Currently Registered Channel' section.