### PR TITLE
feat: Add discussion group support and wizard UI for channel setup

### DIFF
--- a/core/database/SellerSalesChannelRepository.php
+++ b/core/database/SellerSalesChannelRepository.php
@@ -20,21 +20,22 @@ class SellerSalesChannelRepository
 
     /**
      * Menambah atau memperbarui channel jualan untuk seorang penjual.
-     * Jika penjual sudah punya channel, channel ID akan diperbarui dan diaktifkan kembali.
+     * Jika penjual sudah punya channel, detailnya akan diperbarui dan diaktifkan kembali.
      *
      * @param int $seller_user_id ID internal pengguna (penjual).
      * @param int $channel_id ID channel Telegram.
+     * @param int|null $discussion_group_id ID grup diskusi yang terhubung (opsional).
      * @return bool True jika berhasil.
      */
-    public function createOrUpdate(int $seller_user_id, int $channel_id): bool
+    public function createOrUpdate(int $seller_user_id, int $channel_id, ?int $discussion_group_id = null): bool
     {
         // Menggunakan ON DUPLICATE KEY UPDATE yang bergantung pada kunci unik di seller_user_id
-        $sql = "INSERT INTO seller_sales_channels (seller_user_id, channel_id, is_active)
-                VALUES (?, ?, 1)
-                ON DUPLICATE KEY UPDATE channel_id = VALUES(channel_id), is_active = 1";
+        $sql = "INSERT INTO seller_sales_channels (seller_user_id, channel_id, discussion_group_id, is_active)
+                VALUES (?, ?, ?, 1)
+                ON DUPLICATE KEY UPDATE channel_id = VALUES(channel_id), discussion_group_id = VALUES(discussion_group_id), is_active = 1";
 
         $stmt = $this->pdo->prepare($sql);
-        return $stmt->execute([$seller_user_id, $channel_id]);
+        return $stmt->execute([$seller_user_id, $channel_id, $discussion_group_id]);
     }
 
     /**

--- a/member/channels.php
+++ b/member/channels.php
@@ -3,11 +3,10 @@
  * Halaman Manajemen Channel Jualan untuk Anggota.
  *
  * Halaman ini memungkinkan anggota (penjual) untuk mendaftarkan atau memperbarui
- * channel Telegram mereka yang akan digunakan bot untuk mem-posting konten.
+ * channel Telegram mereka dan grup diskusi yang terhubung.
  */
 session_start();
 
-// Jika belum login, redirect ke halaman login
 if (!isset($_SESSION['member_user_id'])) {
     header("Location: index.php");
     exit;
@@ -23,11 +22,8 @@ $channelRepo = new SellerSalesChannelRepository($pdo);
 $user_id = $_SESSION['member_user_id'];
 $error_message = null;
 $success_message = null;
-
-// Ambil bot_id dari session atau dari sumber lain jika tersedia
-// Untuk saat ini, kita asumsikan ada bot default atau bot pertama yang terdaftar
-// Ini mungkin perlu disesuaikan tergantung pada logika aplikasi yang lebih luas
 $bot_details = null;
+
 try {
     $default_bot_id = get_default_bot_id($pdo);
     if (!$default_bot_id) {
@@ -42,41 +38,60 @@ try {
     $error_message = "Error inisialisasi sistem: " . $e->getMessage();
 }
 
-
-// Handle POST request (form submission)
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['channel_identifier']) && empty($error_message)) {
     $channel_identifier = trim($_POST['channel_identifier']);
+    $group_identifier = trim($_POST['group_identifier'] ?? '');
 
     if (empty($channel_identifier)) {
         $error_message = "ID atau username channel tidak boleh kosong.";
     } else {
         try {
-            // 1. Verifikasi bot adalah admin di channel target
             $bot_id = $telegram_api->getBotId();
-            $bot_member = $telegram_api->getChatMember($channel_identifier, $bot_id);
 
-            if (!$bot_member || !$bot_member['ok'] || !in_array($bot_member['result']['status'], ['administrator', 'creator'])) {
-                throw new Exception("Pendaftaran gagal: Pastikan bot telah ditambahkan sebagai *admin* di channel `{$channel_identifier}`.");
+            // 1. Verifikasi Channel
+            $bot_member_channel = $telegram_api->getChatMember($channel_identifier, $bot_id);
+            if (!$bot_member_channel || !$bot_member_channel['ok'] || !in_array($bot_member_channel['result']['status'], ['administrator', 'creator'])) {
+                throw new Exception("Verifikasi Channel Gagal: Pastikan bot telah ditambahkan sebagai *admin* di channel `{$channel_identifier}`.");
             }
-
-            // 2. Verifikasi bot memiliki izin untuk posting
-            if (!($bot_member['result']['can_post_messages'] ?? false)) {
-                throw new Exception("Pendaftaran gagal: Bot memerlukan izin untuk *'Post Messages'* di channel tersebut.");
+            if (!($bot_member_channel['result']['can_post_messages'] ?? false)) {
+                throw new Exception("Verifikasi Channel Gagal: Bot memerlukan izin untuk *'Post Messages'* di channel.");
             }
-
-            // 3. Dapatkan informasi channel untuk menyimpan ID numeriknya
             $channel_info = $telegram_api->getChat($channel_identifier);
             if (!$channel_info || !$channel_info['ok']) {
-                throw new Exception("Pendaftaran gagal: Tidak dapat mengambil informasi untuk channel `{$channel_identifier}`. Pastikan ID atau username sudah benar.");
+                throw new Exception("Verifikasi Channel Gagal: Tidak dapat mengambil informasi untuk channel `{$channel_identifier}`.");
             }
             $numeric_channel_id = $channel_info['result']['id'];
             $channel_title = $channel_info['result']['title'];
+            $linked_chat_id = $channel_info['result']['linked_chat_id'] ?? null;
 
-            // 4. Simpan ke database
-            $success = $channelRepo->createOrUpdate($user_id, $numeric_channel_id);
+            // 2. Verifikasi Grup Diskusi (jika diisi)
+            $numeric_group_id = null;
+            if (!empty($group_identifier)) {
+                $group_info = $telegram_api->getChat($group_identifier);
+                if (!$group_info || !$group_info['ok']) {
+                    throw new Exception("Verifikasi Grup Gagal: Tidak dapat mengambil informasi untuk grup `{$group_identifier}`.");
+                }
+                $numeric_group_id = $group_info['result']['id'];
+
+                // Verifikasi bahwa grup ini memang terhubung dengan channel
+                if ($numeric_group_id != $linked_chat_id) {
+                    throw new Exception("Verifikasi Grup Gagal: Grup `{$group_identifier}` tidak terhubung dengan channel `{$channel_identifier}` di pengaturan Telegram.");
+                }
+            } elseif ($linked_chat_id) {
+                // Jika user tidak mengisi grup tapi channel punya linked group, gunakan itu
+                $numeric_group_id = $linked_chat_id;
+            }
+
+            // 3. Simpan ke database
+            $success = $channelRepo->createOrUpdate($user_id, $numeric_channel_id, $numeric_group_id);
 
             if ($success) {
-                $success_message = "Selamat! Channel '{$channel_title}' (`{$numeric_channel_id}`) telah berhasil didaftarkan sebagai channel jualan Anda.";
+                $success_message = "Selamat! Channel '{$channel_title}' telah berhasil didaftarkan.";
+                 if ($numeric_group_id) {
+                    $group_info = $telegram_api->getChat($numeric_group_id);
+                    $group_title = $group_info['ok'] ? $group_info['result']['title'] : 'grup diskusi';
+                    $success_message .= " Grup diskusi '{$group_title}' juga telah terhubung.";
+                 }
             } else {
                 $error_message = "Terjadi kesalahan database saat mencoba mendaftarkan channel ini.";
             }
@@ -87,35 +102,36 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['channel_identifier'])
     }
 }
 
-// Ambil channel yang terdaftar saat ini untuk ditampilkan
 $current_channel = $channelRepo->findBySellerId($user_id);
 if ($current_channel) {
-    // Inisialisasi kunci array untuk menghindari warning
     $current_channel['title'] = 'Info tidak tersedia';
     $current_channel['username'] = null;
+    $current_channel['group_title'] = null;
 
-    // Jika channel ada, coba dapatkan info terbarunya dari Telegram
     try {
-        if (!isset($telegram_api)) { throw new Exception("API Telegram tidak terinisialisasi."); }
-        $chat_info = $telegram_api->getChat($current_channel['channel_id']);
-        if ($chat_info && $chat_info['ok']) {
-            $current_channel['title'] = $chat_info['result']['title'];
-            $current_channel['username'] = $chat_info['result']['username'] ?? null;
+        if (isset($telegram_api)) {
+            $chat_info = $telegram_api->getChat($current_channel['channel_id']);
+            if ($chat_info && $chat_info['ok']) {
+                $current_channel['title'] = $chat_info['result']['title'];
+                $current_channel['username'] = $chat_info['result']['username'] ?? null;
+            }
+            if (!empty($current_channel['discussion_group_id'])) {
+                 $group_info = $telegram_api->getChat($current_channel['discussion_group_id']);
+                 if ($group_info && $group_info['ok']) {
+                    $current_channel['group_title'] = $group_info['result']['title'];
+                 }
+            }
         }
     } catch (Exception $e) {
-        // Biarkan title default, karena sudah diatur sebagai 'Info tidak tersedia' atau 'Gagal mengambil'
-        $current_channel['title'] = 'Gagal mengambil info channel.';
-        $error_message = $error_message ?? "Gagal menghubungi Telegram: " . $e->getMessage();
+        $error_message = $error_message ?? "Gagal menghubungi Telegram untuk memperbarui info: " . $e->getMessage();
     }
 }
-
 
 $page_title = 'Manajemen Channel';
 require_once __DIR__ . '/../partials/header.php';
 ?>
 
 <h2>Manajemen Channel Jualan</h2>
-<p>Daftarkan channel Telegram Anda di sini. Bot akan menggunakan channel ini untuk mem-posting pratinjau konten Anda.</p>
 
 <?php if ($error_message): ?>
     <div class="alert alert-danger"><?= nl2br(htmlspecialchars($error_message)) ?></div>
@@ -124,41 +140,62 @@ require_once __DIR__ . '/../partials/header.php';
     <div class="alert alert-success"><?= nl2br(htmlspecialchars($success_message)) ?></div>
 <?php endif; ?>
 
-
-<div class="dashboard-card" style="margin-top: 20px;">
-    <h3>Channel Terdaftar Saat Ini</h3>
-    <?php if ($current_channel): ?>
+<?php if ($current_channel): ?>
+    <!-- Management View -->
+    <div class="dashboard-card" style="margin-top: 20px;">
+        <h3>Channel Terdaftar</h3>
         <p>
             <strong>Nama Channel:</strong> <?= htmlspecialchars($current_channel['title']) ?><br>
             <strong>ID Channel:</strong> <code><?= htmlspecialchars($current_channel['channel_id']) ?></code><br>
             <?php if ($current_channel['username']): ?>
                 <strong>Username:</strong> @<?= htmlspecialchars($current_channel['username']) ?><br>
             <?php endif; ?>
+
+            <?php if ($current_channel['group_title']): ?>
+                <strong>Grup Diskusi:</strong> <?= htmlspecialchars($current_channel['group_title']) ?><br>
+            <?php endif; ?>
+
             <?php if ($bot_details && isset($bot_details['username'])): ?>
                 <strong>Terhubung dengan Bot:</strong> @<?= htmlspecialchars($bot_details['username']) ?><br>
             <?php endif; ?>
             <strong>Status:</strong> <span style="color: green; font-weight: bold;">Aktif</span>
         </p>
-    <?php else: ?>
-        <p>Anda belum mendaftarkan channel jualan.</p>
-    <?php endif; ?>
-</div>
+        <hr>
+        <p>Untuk mengubah channel atau grup, silakan daftarkan kembali menggunakan formulir di bawah ini.</p>
+    </div>
+<?php else: ?>
+    <!-- Wizard/Setup View -->
+    <div class="dashboard-card" style="margin-top: 20px;">
+        <h3>Selamat Datang!</h3>
+        <p>Sepertinya Anda belum mendaftarkan channel jualan. Channel jualan digunakan oleh bot untuk mem-posting pratinjau konten Anda. Ikuti langkah-langkah di bawah ini untuk memulai.</p>
+        <h4>Langkah 1: Siapkan Channel Anda</h4>
+        <ol>
+            <li>Buat sebuah Channel baru di Telegram (jika belum punya).</li>
+            <li>Tambahkan bot <strong>@<?= htmlspecialchars($bot_details['username'] ?? 'bot_sistem') ?></strong> sebagai <strong>Admin</strong> di channel Anda.</li>
+            <li>Beri bot izin untuk <strong>'Post Messages'</strong>.</li>
+            <li>(Opsional) Buat Grup Diskusi dan tautkan ke channel Anda melalui Pengaturan Channel di Telegram.</li>
+        </ol>
+    </div>
+<?php endif; ?>
 
 
 <div class="dashboard-card" style="margin-top: 20px;">
-    <h3>Daftarkan atau Perbarui Channel</h3>
-    <p>Masukkan ID Channel atau username (contoh: <code>-100123456789</code> atau <code>@namachannel</code>). Pastikan bot sudah menjadi admin di channel tersebut dengan izin untuk 'Post Messages'.</p>
+    <h3><?= $current_channel ? 'Perbarui Channel dan Grup Diskusi' : 'Langkah 2: Daftarkan Channel Anda' ?></h3>
     <form action="channels.php" method="POST">
         <div style="margin-bottom: 15px;">
             <label for="channel_identifier"><strong>ID atau Username Channel</strong></label>
-            <input type="text" id="channel_identifier" name="channel_identifier" required>
+            <input type="text" id="channel_identifier" name="channel_identifier" required placeholder="@channel_jualan_anda">
+        </div>
+        <div style="margin-bottom: 15px;">
+            <label for="group_identifier"><strong>ID atau Username Grup Diskusi (Opsional)</strong></label>
+            <input type="text" id="group_identifier" name="group_identifier" placeholder="@grup_diskusi_anda">
+            <small>Bot akan mencoba mendeteksi grup secara otomatis jika terhubung di pengaturan Telegram.</small>
         </div>
         <div>
-            <button type="submit" class="btn">Simpan Channel</button>
+            <button type="submit" class="btn">Simpan Konfigurasi</button>
         </div>
     </form>
 </div>
-
 
 <?php
 require_once __DIR__ . '/../partials/footer.php';

--- a/migrations/032_add_discussion_group_to_sales_channels.sql
+++ b/migrations/032_add_discussion_group_to_sales_channels.sql
@@ -1,0 +1,3 @@
+-- Menambahkan kolom untuk menyimpan ID grup diskusi yang terhubung ke channel jualan
+ALTER TABLE `seller_sales_channels`
+ADD COLUMN `discussion_group_id` BIGINT NULL DEFAULT NULL COMMENT 'ID grup diskusi yang terhubung' AFTER `channel_id`;


### PR DESCRIPTION
This commit significantly enhances the 'Channel Management' page by adding support for linking discussion groups and redesigning the UI into a more user-friendly, wizard-like flow.

Key changes:
- Adds a 'discussion_group_id' column to the 'seller_sales_channels' table via a new migration.
- Updates 'SellerSalesChannelRepository' to handle the new database column.
- Redesigns 'member/channels.php' to show a guided setup for new users.
- The form now accepts an optional discussion group, which is verified against the channel's 'linked_chat_id' via the Telegram API.
- The management view now also displays the linked discussion group.