### PR TITLE
feat: Allow members to select a bot for their sales channel

### DIFF
--- a/core/database/SellerSalesChannelRepository.php
+++ b/core/database/SellerSalesChannelRepository.php
@@ -23,19 +23,20 @@ class SellerSalesChannelRepository
      * Jika penjual sudah punya channel, detailnya akan diperbarui dan diaktifkan kembali.
      *
      * @param int $seller_user_id ID internal pengguna (penjual).
+     * @param int $bot_id ID bot yang akan dihubungkan.
      * @param int $channel_id ID channel Telegram.
      * @param int|null $discussion_group_id ID grup diskusi yang terhubung (opsional).
      * @return bool True jika berhasil.
      */
-    public function createOrUpdate(int $seller_user_id, int $channel_id, ?int $discussion_group_id = null): bool
+    public function createOrUpdate(int $seller_user_id, int $bot_id, int $channel_id, ?int $discussion_group_id = null): bool
     {
         // Menggunakan ON DUPLICATE KEY UPDATE yang bergantung pada kunci unik di seller_user_id
-        $sql = "INSERT INTO seller_sales_channels (seller_user_id, channel_id, discussion_group_id, is_active)
-                VALUES (?, ?, ?, 1)
-                ON DUPLICATE KEY UPDATE channel_id = VALUES(channel_id), discussion_group_id = VALUES(discussion_group_id), is_active = 1";
+        $sql = "INSERT INTO seller_sales_channels (seller_user_id, bot_id, channel_id, discussion_group_id, is_active)
+                VALUES (?, ?, ?, ?, 1)
+                ON DUPLICATE KEY UPDATE bot_id = VALUES(bot_id), channel_id = VALUES(channel_id), discussion_group_id = VALUES(discussion_group_id), is_active = 1";
 
         $stmt = $this->pdo->prepare($sql);
-        return $stmt->execute([$seller_user_id, $channel_id, $discussion_group_id]);
+        return $stmt->execute([$seller_user_id, $bot_id, $channel_id, $discussion_group_id]);
     }
 
     /**

--- a/core/helpers.php
+++ b/core/helpers.php
@@ -164,3 +164,15 @@ function get_bot_details(PDO $pdo, int $bot_id): ?array
     $result = $stmt->fetch(PDO::FETCH_ASSOC);
     return $result ?: null;
 }
+
+/**
+ * Mendapatkan semua bot yang terdaftar di sistem.
+ *
+ * @param PDO $pdo Objek koneksi PDO.
+ * @return array Daftar semua bot.
+ */
+function get_all_bots(PDO $pdo): array
+{
+    $stmt = $pdo->query("SELECT id, name, username FROM bots ORDER BY name ASC");
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}

--- a/migrations/033_add_bot_id_to_sales_channels.sql
+++ b/migrations/033_add_bot_id_to_sales_channels.sql
@@ -1,0 +1,4 @@
+-- Menambahkan kolom bot_id untuk menautkan channel jualan ke bot tertentu
+ALTER TABLE `seller_sales_channels`
+ADD COLUMN `bot_id` INT NULL COMMENT 'Referensi ke tabel bots' AFTER `seller_user_id`,
+ADD CONSTRAINT `fk_sales_channels_bot_id` FOREIGN KEY (`bot_id`) REFERENCES `bots`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;


### PR DESCRIPTION
This commit enhances the 'Channel Management' page by allowing members to choose a specific bot to connect to their sales channel. This provides more flexibility in a multi-bot environment.

Key changes:
- Adds a 'bot_id' column to the 'seller_sales_channels' table to store the association.
- Updates 'SellerSalesChannelRepository' to handle the new 'bot_id'.
- Adds a 'get_all_bots' helper function.
- Redesigns the 'member/channels.php' UI to include a bot selection dropdown.
- The backend logic now uses the selected bot for verification and saves the choice.