### PR TITLE
fix: Use correct bot user ID for Telegram API calls

### DIFF
--- a/member/channels.php
+++ b/member/channels.php
@@ -42,7 +42,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['channel_identifier'])
             $telegram_api = new TelegramAPI($bot_token);
 
             // Verifikasi Channel
-            $bot_member_channel = $telegram_api->getChatMember($channel_identifier, $selected_bot_id);
+            $bot_member_channel = $telegram_api->getChatMember($channel_identifier, $telegram_api->getBotId());
             if (!$bot_member_channel || !$bot_member_channel['ok'] || !in_array($bot_member_channel['result']['status'], ['administrator', 'creator'])) {
                 throw new Exception("Verifikasi Channel Gagal: Pastikan bot yang dipilih telah ditambahkan sebagai admin di channel `{$channel_identifier}`.");
             }


### PR DESCRIPTION
This commit fixes a bug on the 'Channel Management' page that caused a 'PARTICIPANT_ID_INVALID' error from the Telegram API.

The issue was that the internal database ID of the bot was being passed to the 'getChatMember' method instead of the bot's actual Telegram User ID. The code has been corrected to use the proper ID, which is retrieved via the 'getMe()' API call encapsulated in the TelegramAPI class.