### PR TITLE
fix: Convert migration to PHP to avoid transaction error

### DIFF
--- a/migrations/034_make_discussion_group_not_null.php
+++ b/migrations/034_make_discussion_group_not_null.php
@@ -1,0 +1,32 @@
+<?php
+
+// Migration to make the discussion_group_id column NOT NULL.
+
+// This script should be run by a migration runner that provides the $pdo object.
+// If running standalone, we need to establish a connection.
+if (!isset($pdo)) {
+    // Attempt to include the database connection setup if not already available.
+    // This path might need adjustment depending on the runner's working directory.
+    $db_path = __DIR__ . '/../core/database.php';
+    if (file_exists($db_path)) {
+        require_once $db_path;
+        $pdo = get_db_connection();
+    } else {
+        echo "Error: Database connection file not found for migration 034." . PHP_EOL;
+        exit(1);
+    }
+}
+
+if ($pdo) {
+    try {
+        $sql = "ALTER TABLE `seller_sales_channels` MODIFY COLUMN `discussion_group_id` BIGINT NOT NULL COMMENT 'ID grup diskusi yang terhubung';";
+        $pdo->exec($sql);
+        echo "Migration 034 successful: discussion_group_id is now NOT NULL." . PHP_EOL;
+    } catch (Exception $e) {
+        echo "Error executing migration 034: " . $e->getMessage() . PHP_EOL;
+        throw $e;
+    }
+} else {
+    echo "Error: Could not get database connection for migration 034." . PHP_EOL;
+    exit(1);
+}

--- a/migrations/034_make_discussion_group_not_null.sql
+++ b/migrations/034_make_discussion_group_not_null.sql
@@ -1,3 +1,0 @@
--- Mengubah kolom discussion_group_id menjadi NOT NULL untuk memastikan setiap channel jualan memiliki grup diskusi
-ALTER TABLE `seller_sales_channels`
-MODIFY COLUMN `discussion_group_id` BIGINT NOT NULL COMMENT 'ID grup diskusi yang terhubung';


### PR DESCRIPTION
This commit fixes a 'There is no active transaction' error that occurred when running database migrations.

The issue was caused by the migration runner's interaction with DDL statements (`ALTER TABLE`) inside a transaction. The migration '034_make_discussion_group_not_null.sql' has been converted to a PHP script ('034_make_discussion_group_not_null.php') to provide more control over the execution and bypass the implicit commit issue.