### PR TITLE
Perbaikan: Mengatasi error fatal pada BotRepository

### DIFF
--- a/core/database/BotRepository.php
+++ b/core/database/BotRepository.php
@@ -25,21 +25,23 @@ class BotRepository
      */
     public function findBotByTelegramId(int $telegram_bot_id)
     {
-        $stmt = $this->pdo->prepare("SELECT telegram_bot_id, token FROM bots WHERE telegram_bot_id = ?");
-        $stmt->execute([$telegram_bot_id]);
+        // Menggunakan LIKE pada token adalah cara paling andal untuk menemukan bot,
+        // karena kolom telegram_bot_id mungkin belum ada jika migrasi tertentu belum dijalankan.
+        $stmt = $this->pdo->prepare("SELECT id, token FROM bots WHERE token LIKE ?");
+        $stmt->execute([$telegram_bot_id . ':%']);
         return $stmt->fetch(PDO::FETCH_ASSOC);
     }
 
     /**
      * Mengambil semua pengaturan untuk bot tertentu, dengan nilai default jika tidak disetel.
      *
-     * @param int $telegram_bot_id ID Telegram bot dari tabel `bots`.
+     * @param int $bot_id ID internal bot dari tabel `bots`.
      * @return array Pengaturan bot sebagai array asosiatif.
      */
-    public function getBotSettings(int $telegram_bot_id): array
+    public function getBotSettings(int $bot_id): array
     {
         $stmt_settings = $this->pdo->prepare("SELECT setting_key, setting_value FROM bot_settings WHERE bot_id = ?");
-        $stmt_settings->execute([$telegram_bot_id]);
+        $stmt_settings->execute([$bot_id]);
         $bot_settings_raw = $stmt_settings->fetchAll(PDO::FETCH_KEY_PAIR);
 
         // Tetapkan pengaturan default jika tidak ada di database


### PR DESCRIPTION
Memperbaiki error `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'telegram_bot_id'` yang muncul setelah refactoring dispatcher.

- Mengubah `BotRepository::findBotByTelegramId` untuk mencari bot menggunakan `token LIKE ?` agar lebih andal dan tidak bergantung pada kolom `telegram_bot_id` yang mungkin belum ada. Metode ini sekarang mengambil `id` internal bot.
- Mengubah `BotRepository::getBotSettings` untuk menerima `bot_id` internal sebagai parameter, sesuai dengan skema tabel `bot_settings`.
- Memperbarui `UpdateDispatcher` untuk menggunakan `id` internal bot saat memanggil `getBotSettings`.
- Memastikan `telegram_bot_id` yang diperlukan oleh `TelegramAPI` dan `UserRepository` diekstrak secara konsisten dari token bot, bukan dari array `$bot`.