### PR TITLE
Perbaikan: Atasi `TypeError` pada pemanggilan `getBotSettings`

### DIFF
--- a/core/UpdateDispatcher.php
+++ b/core/UpdateDispatcher.php
@@ -34,7 +34,7 @@ class UpdateDispatcher
         $this->update = $update;
 
         $bot_repo = new BotRepository($pdo);
-        $this->bot_settings = $bot_repo->getBotSettings($bot['id']);
+        $this->bot_settings = $bot_repo->getBotSettings((int)$bot['id']);
 
         $this->update_handler = new UpdateHandler($this->bot_settings);
 


### PR DESCRIPTION
Menambahkan casting `(int)` pada `$bot['id']` di dalam `UpdateDispatcher` sebelum memanggil `getBotSettings`.

Ini untuk memperbaiki `TypeError` yang terjadi karena PDO mengembalikan ID dari database sebagai string, sementara metode `getBotSettings` secara eksplisit membutuhkan integer.