### PR TITLE
Perbaikan: Atasi error nested transaction di UserRepository

### DIFF
--- a/core/database/UserRepository.php
+++ b/core/database/UserRepository.php
@@ -37,7 +37,7 @@ class UserRepository
 
         if (!$current_user) {
             // Pengguna tidak ada, buat baru.
-            $this->pdo->beginTransaction();
+            // Transaksi sekarang dikelola oleh UpdateDispatcher, jadi kita tidak perlu memulainya di sini.
             try {
                 // 1. Masukkan ke tabel `users`
                 // Gunakan INSERT IGNORE untuk menghindari error jika pengguna sudah ada (misal, dari request konkuren)
@@ -59,12 +59,11 @@ class UserRepository
                     $stmt_user_role->execute([$telegram_user_id, $role_id]);
                 }
 
-                $this->pdo->commit();
                 app_log("Pengguna baru dibuat atau diverifikasi: telegram_id: {$telegram_user_id}, user: {$first_name}, peran: {$initial_role_name}", 'bot');
             } catch (Exception $e) {
-                $this->pdo->rollBack();
+                // Jangan rollback di sini. Lemparkan kembali agar dispatcher bisa melakukan rollback.
                 app_log("Gagal membuat pengguna baru: " . $e->getMessage(), 'error');
-                return false;
+                throw $e;
             }
         }
 


### PR DESCRIPTION
- Menghapus panggilan `beginTransaction`, `commit`, dan `rollBack` dari metode `findOrCreateUser` di `UserRepository.php`.
- Mengubah blok `catch` untuk melempar kembali (re-throw) exception, memungkinkan `UpdateDispatcher` untuk menangani rollback transaksi secara terpusat.
- Ini memperbaiki error `There is already an active transaction` dan memastikan integritas data selama pembuatan pengguna baru.