### PR TITLE
Perbaiki: Fatal Error pada Webhook karena ID Bot Salah

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.3.1] - 2025-08-27
+
+### Diperbaiki
+- **Fatal Error pada Webhook**: Memperbaiki error `500 Internal Server Error` yang terjadi saat webhook menerima pembaruan.
+  - **Penyebab**: `UpdateDispatcher` menggunakan ID Telegram bot (`telegram_bot_id`) saat mencoba menyimpan pesan ke database, padahal seharusnya menggunakan ID internal bot dari tabel `bots`. Hal ini menyebabkan pelanggaran *foreign key constraint* dan memicu `PDOException`.
+  - **Solusi**: Mengubah panggilan `execute()` di metode `logIncomingMessage` dalam `core/UpdateDispatcher.php` untuk menggunakan `(int)$this->bot['id']` yang benar.
+
 ## [4.3.0] - 2025-08-25
 
 ### Diubah (Refactoring Besar)

--- a/core/UpdateDispatcher.php
+++ b/core/UpdateDispatcher.php
@@ -148,7 +148,7 @@ class UpdateDispatcher
         );
         $stmt->execute([
             $user_id,
-            $this->telegram_bot_id,
+            (int)$this->bot['id'],
             $telegram_message_id,
             $chat_id,
             $chat_type,


### PR DESCRIPTION
Memperbaiki `500 Internal Server Error` yang terjadi saat webhook menerima pembaruan.

Penyebab masalah ini adalah `UpdateDispatcher` yang menggunakan ID Telegram bot (`telegram_bot_id`) saat mencoba menyimpan pesan ke database. Seharusnya, ia menggunakan ID internal dari tabel `bots`. Penggunaan ID yang salah ini menyebabkan pelanggaran *foreign key constraint* dan memicu `PDOException` yang tidak tertangani, yang akhirnya mengakibatkan respons 500.

Perubahan ini memperbaiki logika di metode `logIncomingMessage` dalam file `core/UpdateDispatcher.php`. Sekarang, metode tersebut menggunakan `(int)$this->bot['id']` yang benar, memastikan integritas data dan menyelesaikan error fatal.