### PR TITLE
Perbaiki: Serangkaian Error Fatal pada Webhook dan Pembuatan User

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - **Fatal Error pada Webhook**: Memperbaiki error `500 Internal Server Error` yang terjadi saat webhook menerima pembaruan.
   - **Penyebab**: `UpdateDispatcher` menggunakan ID Telegram bot (`telegram_bot_id`) saat mencoba menyimpan pesan ke database, padahal seharusnya menggunakan ID internal bot dari tabel `bots`. Hal ini menyebabkan pelanggaran *foreign key constraint* dan memicu `PDOException`.
   - **Solusi**: Mengubah panggilan `execute()` di metode `logIncomingMessage` dalam `core/UpdateDispatcher.php` untuk menggunakan `(int)$this->bot['id']` yang benar.
+- **Fatal Error saat Membuat Pengguna**: Memperbaiki error `SQLSTATE[42S22]: Unknown column 'telegram_id'` yang terjadi saat pengguna baru pertama kali berinteraksi dengan bot.
+  - **Penyebab**: `UserRepository` mencoba memasukkan data ke kolom `telegram_id` pada tabel `users`, tetapi skema database yang aktif saat ini masih menggunakan `id` sebagai primary key. Terjadi inkonsistensi antara kode dan skema database yang sebenarnya.
+  - **Solusi**: Mengubah query `INSERT` di metode `findOrCreateUser` dalam `core/database/UserRepository.php` untuk menggunakan kolom `id` yang benar.
 
 ## [4.3.0] - 2025-08-25
 

--- a/core/database/UserRepository.php
+++ b/core/database/UserRepository.php
@@ -41,7 +41,7 @@ class UserRepository
             try {
                 // 1. Masukkan ke tabel `users`
                 // Gunakan INSERT IGNORE untuk menghindari error jika pengguna sudah ada (misal, dari request konkuren)
-                $stmt_insert = $this->pdo->prepare("INSERT IGNORE INTO users (telegram_id, first_name, username) VALUES (?, ?, ?)");
+                $stmt_insert = $this->pdo->prepare("INSERT IGNORE INTO users (id, first_name, username) VALUES (?, ?, ?)");
                 $stmt_insert->execute([$telegram_user_id, $first_name, $username]);
 
                 // 2. Tentukan peran awal


### PR DESCRIPTION
Commit ini menyelesaikan dua error fatal yang menyebabkan webhook gagal berfungsi.

1.  **Error Foreign Key di `UpdateDispatcher`**:
    - **Masalah**: Webhook gagal dengan `500 Internal Server Error` karena `UpdateDispatcher` menggunakan ID Telegram bot, bukan ID internal database, saat menyimpan pesan. Hal ini menyebabkan pelanggaran *foreign key constraint*.
    - **Solusi**: Memperbaiki `logIncomingMessage` di `core/UpdateDispatcher.php` untuk menggunakan `(int)$this->bot['id']`.

2.  **Error Kolom Tidak Dikenal di `UserRepository`**:
    - **Masalah**: Setelah perbaikan pertama, muncul error `Unknown column 'telegram_id'` saat membuat pengguna baru. Ini disebabkan oleh inkonsistensi di `UserRepository`, di mana query `INSERT` menggunakan nama kolom `telegram_id` sementara skema database yang aktif masih menggunakan `id`.
    - **Solusi**: Menyamakan query `INSERT` di `core/database/UserRepository.php` untuk menggunakan kolom `id` yang benar.

Kedua perbaikan ini secara kolektif menstabilkan alur pemrosesan webhook dan pembuatan pengguna baru.