### PR TITLE
Perbaiki: Alur Login Member Gagal Total karena Inkonsistensi Kolom ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - **Login Member Gagal**: Memperbaiki masalah di mana token login untuk panel member selalu ditolak sebagai "tidak valid".
   - **Penyebab**: Perintah `/login` gagal menyimpan token yang baru dibuat ke database. Ini karena query `UPDATE` pada tabel `members` menggunakan kunci array yang salah (`telegram_id` bukan `id`) untuk mengidentifikasi pengguna.
   - **Solusi**: Mengubah `handleLoginCommand` di `core/handlers/MessageHandler.php` untuk menggunakan `$app->user['id']` yang benar saat menyimpan token.
+- **Fatal Error di Panel Member**: Memperbaiki error `SQLSTATE[42S22]: Column not found` yang terjadi setelah validasi token berhasil.
+  - **Penyebab**: Query untuk mengambil informasi pengguna di `member/index.php` setelah login berhasil, masih menggunakan kolom `telegram_id` yang salah, bukan `id`.
+  - **Solusi**: Menyamakan query di `member/index.php` untuk menggunakan kolom `id` yang benar.
 
 ## [4.3.1] - 2025-08-27
 

--- a/member/index.php
+++ b/member/index.php
@@ -64,7 +64,7 @@ function process_login_token($token, $pdo) {
         $_SESSION['member_user_id'] = $user_telegram_id;
 
         // Ambil info pengguna untuk logging yang lebih baik
-        $user_info_stmt = $pdo->prepare("SELECT first_name, username FROM users WHERE telegram_id = ?");
+        $user_info_stmt = $pdo->prepare("SELECT first_name, username FROM users WHERE id = ?");
         $user_info_stmt->execute([$user_telegram_id]);
         $user_info = $user_info_stmt->fetch(PDO::FETCH_ASSOC);
 


### PR DESCRIPTION
Memperbaiki serangkaian error yang menyebabkan alur login member gagal total. Masalah ini disebabkan oleh inkonsistensi sistematis dalam penggunaan nama kolom untuk ID pengguna (`id` vs. `telegram_id`) di beberapa file.

Perbaikan ini mencakup:

1.  **Penyimpanan Token di `MessageHandler.php`**:
    - **Masalah**: Perintah `/login` gagal menyimpan token ke database karena query `UPDATE` menggunakan kunci array `telegram_id` yang tidak ada, bukan `id`.
    - **Solusi**: Mengubah query untuk menggunakan `$app->user['id']` yang benar.

2.  **Validasi Token di `member/index.php`**:
    - **Masalah**: Setelah token divalidasi, skrip gagal mengambil data pengguna karena query `SELECT` juga menggunakan kolom `telegram_id` yang tidak ada.
    - **Solusi**: Mengubah query untuk mencari pengguna berdasarkan kolom `id` yang benar.

Dengan menyelaraskan semua query ini untuk secara konsisten menggunakan kolom `id`, alur login member dari pembuatan token hingga login berhasil kini telah dipulihkan.