### PR TITLE
Perbaiki: Ganti `telegram_bot_id` menjadi `id` untuk konsistensi skema.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.3.4] - 2025-08-27
+
+### Diperbaiki
+- **Fatal Error di Halaman Manajemen Channel**: Memperbaiki error `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'telegram_bot_id'` yang terjadi saat anggota membuka halaman "Manajemen Channel".
+  - **Penyebab**: Kode di `core/helpers.php` dan `member/channels.php` salah merujuk ke kolom `telegram_bot_id` pada tabel `bots`. Berdasarkan investigasi pada `updated_schema.sql`, nama kolom yang benar untuk ID bot adalah `id`. Inkonsistensi ini muncul karena adanya migrasi yang belum sepenuhnya diterapkan atau telah dikembalikan.
+  - **Solusi**: Mengubah semua referensi ke `bots.telegram_bot_id` menjadi `bots.id` di file-file berikut:
+    - `core/helpers.php`: Menyesuaikan fungsi `get_all_bots`, `get_bot_details`, `get_bot_token`, dan `get_default_bot_id`.
+    - `member/channels.php`: Memperbarui logika untuk menangani `bot_id` dari formulir dan saat menampilkan daftar bot.
+
 ## [4.3.3] - 2025-08-27
 
 ### Diperbaiki

--- a/core/helpers.php
+++ b/core/helpers.php
@@ -130,7 +130,7 @@ function get_sort_link(string $column, string $current_sort_by, string $current_
  */
 function get_default_bot_id(PDO $pdo): ?int
 {
-    $stmt = $pdo->query("SELECT telegram_bot_id FROM bots ORDER BY created_at ASC LIMIT 1");
+    $stmt = $pdo->query("SELECT id FROM bots ORDER BY created_at ASC LIMIT 1");
     $result = $stmt->fetchColumn();
     return $result ? (int)$result : null;
 }
@@ -139,28 +139,28 @@ function get_default_bot_id(PDO $pdo): ?int
  * Mendapatkan token API untuk bot tertentu.
  *
  * @param PDO $pdo Objek koneksi PDO.
- * @param int $telegram_bot_id ID Telegram bot.
+ * @param int $bot_id ID bot.
  * @return string|null Token bot atau null jika tidak ditemukan.
  */
-function get_bot_token(PDO $pdo, int $telegram_bot_id): ?string
+function get_bot_token(PDO $pdo, int $bot_id): ?string
 {
-    $stmt = $pdo->prepare("SELECT token FROM bots WHERE telegram_bot_id = ?");
-    $stmt->execute([$telegram_bot_id]);
+    $stmt = $pdo->prepare("SELECT token FROM bots WHERE id = ?");
+    $stmt->execute([$bot_id]);
     $token = $stmt->fetchColumn();
     return $token ?: null;
 }
 
 /**
- * Mendapatkan detail lengkap sebuah bot berdasarkan ID Telegram-nya.
+ * Mendapatkan detail lengkap sebuah bot berdasarkan ID-nya.
  *
  * @param PDO $pdo Objek koneksi PDO.
- * @param int $telegram_bot_id ID Telegram bot.
+ * @param int $bot_id ID bot.
  * @return array|null Detail bot sebagai array asosiatif, atau null jika tidak ditemukan.
  */
-function get_bot_details(PDO $pdo, int $telegram_bot_id): ?array
+function get_bot_details(PDO $pdo, int $bot_id): ?array
 {
-    $stmt = $pdo->prepare("SELECT * FROM bots WHERE telegram_bot_id = ?");
-    $stmt->execute([$telegram_bot_id]);
+    $stmt = $pdo->prepare("SELECT * FROM bots WHERE id = ?");
+    $stmt->execute([$bot_id]);
     $result = $stmt->fetch(PDO::FETCH_ASSOC);
     return $result ?: null;
 }
@@ -173,6 +173,6 @@ function get_bot_details(PDO $pdo, int $telegram_bot_id): ?array
  */
 function get_all_bots(PDO $pdo): array
 {
-    $stmt = $pdo->query("SELECT telegram_bot_id, name, username FROM bots ORDER BY name ASC");
+    $stmt = $pdo->query("SELECT id, name, username FROM bots ORDER BY name ASC");
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }

--- a/member/channels.php
+++ b/member/channels.php
@@ -34,15 +34,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['channel_identifier'])
     } else {
         $_SESSION['last_channel_check'] = time(); // Set time immediately
 
-        $selected_telegram_bot_id = filter_input(INPUT_POST, 'bot_id', FILTER_VALIDATE_INT);
+        $selected_bot_id = filter_input(INPUT_POST, 'bot_id', FILTER_VALIDATE_INT);
         $channel_identifier = trim($_POST['channel_identifier']);
         $group_identifier = trim($_POST['group_identifier'] ?? '');
 
-        if (empty($channel_identifier) || !$selected_telegram_bot_id || empty($group_identifier)) {
+        if (empty($channel_identifier) || !$selected_bot_id || empty($group_identifier)) {
             $error_message = "Harap pilih bot, isi ID/username channel, dan ID/username grup diskusi.";
         } else {
             try {
-                $bot_token = get_bot_token($pdo, $selected_telegram_bot_id);
+                $bot_token = get_bot_token($pdo, $selected_bot_id);
                 if (!$bot_token) {
                     throw new Exception("Bot yang dipilih tidak valid atau tidak memiliki token.");
                 }
@@ -51,7 +51,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['channel_identifier'])
                 // $bot_telegram_id = $telegram_api->getBotId();
 
                 // 1. Verifikasi Channel
-                $bot_member_channel = $telegram_api->getChatMember($channel_identifier, $selected_telegram_bot_id);
+                $bot_member_channel = $telegram_api->getChatMember($channel_identifier, $selected_bot_id);
                 if (!$bot_member_channel || !$bot_member_channel['ok'] || !in_array($bot_member_channel['result']['status'], ['administrator', 'creator'])) {
                     throw new Exception("Verifikasi Channel Gagal: Pastikan bot yang dipilih telah ditambahkan sebagai *admin* di channel `{$channel_identifier}`.");
                 }
@@ -82,13 +82,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['channel_identifier'])
                 }
 
                 // 3. Verifikasi Bot adalah admin di Grup Diskusi
-                $bot_member_group = $telegram_api->getChatMember($numeric_group_id, $selected_telegram_bot_id);
+                $bot_member_group = $telegram_api->getChatMember($numeric_group_id, $selected_bot_id);
                 if (!$bot_member_group || !$bot_member_group['ok'] || !in_array($bot_member_group['result']['status'], ['administrator', 'creator'])) {
                     throw new Exception("Verifikasi Grup Gagal: Pastikan bot yang dipilih juga merupakan *admin* di grup diskusi.");
                 }
 
                 // 4. Simpan ke database
-                $success = $channelRepo->createOrUpdate($user_id, $selected_telegram_bot_id, $numeric_channel_id, $numeric_group_id);
+                $success = $channelRepo->createOrUpdate($user_id, $selected_bot_id, $numeric_channel_id, $numeric_group_id);
 
                 if ($success) {
                     $success_message = "Selamat! Channel '{$channel_title}' dan grup diskusinya telah berhasil dikonfigurasi.";
@@ -173,7 +173,7 @@ require_once __DIR__ . '/../partials/header.php';
             <select id="bot_id" name="bot_id" required>
                 <option value="">-- Pilih Bot --</option>
                 <?php foreach ($all_bots as $bot): ?>
-                    <option value="<?= $bot['telegram_bot_id'] ?>" <?= (isset($current_channel['bot_id']) && $current_channel['bot_id'] == $bot['telegram_bot_id']) ? 'selected' : '' ?>>
+                    <option value="<?= $bot['id'] ?>" <?= (isset($current_channel['bot_id']) && $current_channel['bot_id'] == $bot['id']) ? 'selected' : '' ?>>
                         <?= htmlspecialchars($bot['name']) ?> (@<?= htmlspecialchars($bot['username']) ?>)
                     </option>
                 <?php endforeach; ?>


### PR DESCRIPTION
Memperbaiki error fatal `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'telegram_bot_id'` yang terjadi di halaman manajemen channel.

Penyebabnya adalah inkonsistensi antara kode (yang menggunakan `telegram_bot_id`) dan skema database (`updated_schema.sql`) yang menggunakan `id` sebagai primary key untuk tabel `bots`.

Perubahan ini menyelaraskan basis kode dengan skema database yang benar:
- Mengubah semua query di `core/helpers.php` yang merujuk ke `bots.telegram_bot_id` menjadi `bots.id`.
- Menyesuaikan logika di `member/channels.php` untuk menggunakan `id` saat mengambil dan memproses ID bot.
- Memperbarui `CHANGELOG.md` untuk mencatat perbaikan ini.