### PR TITLE
Perbaiki: Ganti query `members` menjadi `users` di `login_choice.php`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.4.1] - 2025-08-27
+
+### Diperbaiki
+- **Fatal Error di Halaman Pilihan Login**: Memperbaiki error `SQLSTATE[42S02]: Base table or view not found` pada `login_choice.php`.
+  - **Penyebab**: Halaman ini masih mencoba mengakses tabel `members` yang sudah dihapus dan digabungkan ke dalam tabel `users` pada refactoring sebelumnya.
+  - **Solusi**: Mengubah query database di `login_choice.php` untuk mengambil data token langsung dari tabel `users`.
+
 ## [4.4.0] - 2025-08-27
 
 ### Fitur

--- a/login_choice.php
+++ b/login_choice.php
@@ -22,17 +22,17 @@ if (!$token) {
     } else {
         // Cari token dan pastikan belum digunakan dan tidak kedaluwarsa (misal: dalam 5 menit terakhir)
         $stmt = $pdo->prepare(
-            "SELECT user_id FROM members WHERE login_token = ? AND token_used = 0 AND token_created_at >= NOW() - INTERVAL 5 MINUTE"
+            "SELECT id FROM users WHERE login_token = ? AND token_used = 0 AND token_created_at >= NOW() - INTERVAL 5 MINUTE"
         );
         $stmt->execute([$token]);
-        $member = $stmt->fetch();
+        $user = $stmt->fetch();
 
-        if ($member) {
+        if ($user) {
             // Sebelum menampilkan link, pastikan pengguna ini memang admin
             $stmt_check_admin = $pdo->prepare(
                 "SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.user_id = ? AND r.name = 'Admin'"
             );
-            $stmt_check_admin->execute([$member['user_id']]);
+            $stmt_check_admin->execute([$user['id']]);
             if ($stmt_check_admin->fetch()) {
                 $is_token_valid = true;
             } else {


### PR DESCRIPTION
Memperbaiki error fatal `SQLSTATE[42S02]: Base table or view not found` yang terjadi pada halaman `login_choice.php`.

Penyebabnya adalah halaman tersebut masih mencoba mengakses tabel `members` yang sudah dihapus dan digabungkan ke dalam tabel `users` pada refactoring sebelumnya.

Perubahan ini menyesuaikan query database di `login_choice.php` untuk mengambil data token langsung dari tabel `users`, yang menyelesaikan masalah tersebut.