### PR TITLE
Fix: Perbaiki inkonsistensi nama kolom `id` bot di seluruh codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@
 10. **Lakukan publish** agar kode bisa langsung dicek.
 11. Selalu lakukan pemeriksaan menyeluruh pada seluruh basis kode setiap kali ada proses generate atau perbaikan, bukan hanya di satu file.
 12. Identifikasi pola masalah secara global (misalnya inkonsistensi antar file), lalu langsung perbaiki secara sistematis.
+13. Selalu lakukan pemeriksaan menyeluruh setiap kali proses generate/perbaikan → pastikan semua file terkait ikut diperiksa (tidak boleh ada yg terlewat).
+14. Jika ada error tambahan, langsung analisis global untuk mencari potensi file lain yg mungkin terdampak.
 
 ---
 
@@ -24,7 +26,11 @@
 3. **Jangan menggunakan kalimat basa-basi**.
 4. **Jangan menuliskan janji tindakan** seperti “akan mengerjakan” → langsung tampilkan langkah perbaikan yang bisa dipakai.
 5. **Jangan membuat asumsi tunggal tanpa dasar** → jika tidak pasti, berikan beberapa opsi solusi.
-6. Jangan menulis kalimat retrospektif seperti “Seharusnya saya melakukan pemeriksaan sejak awal”.
-7. Jangan berhenti di satu titik error saja → selalu periksa keseluruhan project.
+6. **Jangan menulis kalimat retrospektif seperti “Seharusnya saya melakukan pemeriksaan sejak awal”.
+7. **Jangan berhenti di satu titik error saja → selalu periksa keseluruhan project.
+8. **Jangan meminta maaf** atau menyalahkan diri sendiri.
+9. **Jangan menyalahkan kelalaian** seperti “melewatkan file” → cukup nyatakan fakta teknis.
+10. **Jangan membuat rencana** (misalnya: “akan memperbaiki nanti”, “akan membuat rencana baru”).
+11. **Jangan berhenti di error saat ini saja** → selalu cek apakah ada file lain yg mungkin bermasalah agar masalah tuntas sekali jalan.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.4.2] - 2025-08-27
+
+### Diperbaiki
+- **Fatal Error di Dasbor Percakapan**: Memperbaiki error `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'telegram_bot_id'` di halaman utama admin (`admin/index.php`).
+  - **Penyebab**: Kode di `admin/index.php` mencoba mengambil kolom `telegram_bot_id` dari tabel `bots`, padahal skema database yang benar (`updated_schema.sql`) menamai kolom tersebut `id`.
+  - **Solusi**: Mengubah semua referensi ke `telegram_bot_id` menjadi `id` di `admin/index.php`, termasuk query SQL dan variabel terkait, agar sesuai dengan struktur database.
+
 ## [4.4.1] - 2025-08-27
 
 ### Diperbaiki

--- a/admin/bot_manager.php
+++ b/admin/bot_manager.php
@@ -28,10 +28,10 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 // TODO: Add admin authentication check here
 
 $action = $_POST['action'] ?? null;
-$telegram_bot_id = isset($_POST['bot_id']) ? (int)$_POST['bot_id'] : 0;
+$bot_id = isset($_POST['bot_id']) ? (int)$_POST['bot_id'] : 0;
 $response = ['status' => 'error', 'message' => 'Aksi tidak diketahui.'];
 
-if ($action === 'get_me' && $telegram_bot_id > 0) {
+if ($action === 'get_me' && $bot_id > 0) {
     try {
         $pdo = get_db_connection();
         if (!$pdo) {
@@ -39,12 +39,12 @@ if ($action === 'get_me' && $telegram_bot_id > 0) {
         }
 
         // 1. Ambil token bot dari database
-        $stmt_token = $pdo->prepare("SELECT token FROM bots WHERE telegram_bot_id = ?");
-        $stmt_token->execute([$telegram_bot_id]);
+        $stmt_token = $pdo->prepare("SELECT token FROM bots WHERE id = ?");
+        $stmt_token->execute([$bot_id]);
         $token = $stmt_token->fetchColumn();
 
         if (!$token) {
-            throw new Exception("Bot dengan ID {$telegram_bot_id} tidak ditemukan.");
+            throw new Exception("Bot dengan ID {$bot_id} tidak ditemukan.");
         }
 
         // 2. Panggil API Telegram
@@ -59,15 +59,15 @@ if ($action === 'get_me' && $telegram_bot_id > 0) {
         $bot_result = $bot_info['result'];
 
         // Verifikasi bahwa token sesuai dengan ID bot yang di-request
-        if ($bot_result['id'] != $telegram_bot_id) {
+        if ($bot_result['id'] != $bot_id) {
             throw new Exception("Token tidak cocok dengan ID bot yang sedang diperbarui. Keamanan terverifikasi.");
         }
 
         $first_name = $bot_result['first_name'];
         $username = $bot_result['username'] ?? null;
 
-        $stmt_update = $pdo->prepare("UPDATE bots SET first_name = ?, username = ? WHERE telegram_bot_id = ?");
-        $stmt_update->execute([$first_name, $username, $telegram_bot_id]);
+        $stmt_update = $pdo->prepare("UPDATE bots SET first_name = ?, username = ? WHERE id = ?");
+        $stmt_update->execute([$first_name, $username, $bot_id]);
 
         $response = [
             'status' => 'success',

--- a/admin/bots.php
+++ b/admin/bots.php
@@ -39,24 +39,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['add_bot'])) {
                 $bot_result = $bot_info['result'];
                 $first_name = $bot_result['first_name'];
                 $username = $bot_result['username'] ?? null;
-                $telegram_bot_id = $bot_result['id'];
+                $bot_id = $bot_result['id'];
 
                 // 2. Cek duplikasi (token atau ID bot) di database
-                $stmt_check_token = $pdo->prepare("SELECT telegram_bot_id FROM bots WHERE token = ?");
+                $stmt_check_token = $pdo->prepare("SELECT id FROM bots WHERE token = ?");
                 $stmt_check_token->execute([$token]);
                 if ($stmt_check_token->fetch()) {
                      throw new Exception("Token ini sudah ada di database.", 23000);
                 }
 
-                $stmt_check_id = $pdo->prepare("SELECT telegram_bot_id FROM bots WHERE telegram_bot_id = ?");
-                $stmt_check_id->execute([$telegram_bot_id]);
+                $stmt_check_id = $pdo->prepare("SELECT id FROM bots WHERE id = ?");
+                $stmt_check_id->execute([$bot_id]);
                 if ($stmt_check_id->fetch()) {
-                     throw new Exception("Bot dengan ID Telegram {$telegram_bot_id} ini sudah terdaftar.", 23000);
+                     throw new Exception("Bot dengan ID Telegram {$bot_id} ini sudah terdaftar.", 23000);
                 }
 
                 // 3. Simpan bot baru ke database
-                $stmt = $pdo->prepare("INSERT INTO bots (telegram_bot_id, first_name, username, token) VALUES (?, ?, ?, ?)");
-                $stmt->execute([$telegram_bot_id, $first_name, $username, $token]);
+                $stmt = $pdo->prepare("INSERT INTO bots (id, first_name, username, token) VALUES (?, ?, ?, ?)");
+                $stmt->execute([$bot_id, $first_name, $username, $token]);
 
                 $success = "Bot '{$first_name}' (@{$username}) berhasil ditambahkan!";
 
@@ -76,7 +76,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['add_bot'])) {
 }
 
 // Ambil daftar bot yang ada
-$bots = $pdo->query("SELECT telegram_bot_id, first_name, username, created_at FROM bots ORDER BY created_at DESC")->fetchAll();
+$bots = $pdo->query("SELECT id, first_name, username, created_at FROM bots ORDER BY created_at DESC")->fetchAll();
 
 $page_title = 'Kelola Bot';
 require_once __DIR__ . '/../partials/header.php';
@@ -115,11 +115,11 @@ require_once __DIR__ . '/../partials/header.php';
         <?php else: ?>
             <?php foreach ($bots as $bot): ?>
                 <tr>
-                    <td><?= htmlspecialchars($bot['telegram_bot_id']) ?></td>
+                    <td><?= htmlspecialchars($bot['id']) ?></td>
                     <td><?= htmlspecialchars($bot['first_name']) ?></td>
                     <td>@<?= htmlspecialchars($bot['username'] ?? 'N/A') ?></td>
                     <td>
-                        <a href="edit_bot.php?id=<?= htmlspecialchars($bot['telegram_bot_id']) ?>" class="btn btn-edit">Edit</a>
+                        <a href="edit_bot.php?id=<?= htmlspecialchars($bot['id']) ?>" class="btn btn-edit">Edit</a>
                     </td>
                 </tr>
             <?php endforeach; ?>

--- a/admin/channel_chat.php
+++ b/admin/channel_chat.php
@@ -16,16 +16,16 @@ if (!$pdo) {
 
 // Validasi input
 $chat_id = isset($_GET['chat_id']) ? (int)$_GET['chat_id'] : 0;
-$telegram_bot_id = isset($_GET['bot_id']) ? (int)$_GET['bot_id'] : 0;
+$bot_id = isset($_GET['bot_id']) ? (int)$_GET['bot_id'] : 0;
 
-if (!$chat_id || !$telegram_bot_id) {
+if (!$chat_id || !$bot_id) {
     header("Location: index.php");
     exit;
 }
 
 // Ambil info bot
-$stmt_bot = $pdo->prepare("SELECT * FROM bots WHERE telegram_bot_id = ?");
-$stmt_bot->execute([$telegram_bot_id]);
+$stmt_bot = $pdo->prepare("SELECT * FROM bots WHERE id = ?");
+$stmt_bot->execute([$bot_id]);
 $bot_info = $stmt_bot->fetch();
 
 if (!$bot_info) {
@@ -34,7 +34,7 @@ if (!$bot_info) {
 
 // Ambil info chat dari pesan terakhir untuk judul halaman
 $stmt_chat_info = $pdo->prepare("SELECT raw_data FROM messages WHERE chat_id = ? AND bot_id = ? ORDER BY id DESC LIMIT 1");
-$stmt_chat_info->execute([$chat_id, $telegram_bot_id]);
+$stmt_chat_info->execute([$chat_id, $bot_id]);
 $last_message_raw = $stmt_chat_info->fetchColumn();
 $chat_title = "Chat ID: $chat_id";
 if ($last_message_raw) {
@@ -48,7 +48,7 @@ $limit = 50;
 $offset = ($page - 1) * $limit;
 
 $count_stmt = $pdo->prepare("SELECT COUNT(*) FROM messages WHERE chat_id = ? AND bot_id = ?");
-$count_stmt->execute([$chat_id, $telegram_bot_id]);
+$count_stmt->execute([$chat_id, $bot_id]);
 $total_messages = $count_stmt->fetchColumn();
 $total_pages = ceil($total_messages / $limit);
 
@@ -62,7 +62,7 @@ $sql = "SELECT m.*, mf.type as media_type, u.first_name as sender_first_name
         LIMIT ? OFFSET ?";
 $stmt = $pdo->prepare($sql);
 $stmt->bindValue(1, $chat_id, PDO::PARAM_INT);
-$stmt->bindValue(2, $telegram_bot_id, PDO::PARAM_INT);
+$stmt->bindValue(2, $bot_id, PDO::PARAM_INT);
 $stmt->bindValue(3, $limit, PDO::PARAM_INT);
 $stmt->bindValue(4, $offset, PDO::PARAM_INT);
 $stmt->execute();
@@ -75,7 +75,7 @@ require_once __DIR__ . '/../partials/header.php';
 
 <div class="chat-container">
     <div class="chat-header">
-        <a href="index.php?bot_id=<?= $telegram_bot_id ?>" class="btn">&larr; Kembali</a>
+        <a href="index.php?bot_id=<?= $bot_id ?>" class="btn">&larr; Kembali</a>
         <h3>Riwayat Chat: <?= htmlspecialchars($chat_title) ?></h3>
         <p>Total Pesan: <?= $total_messages ?></p>
     </div>
@@ -83,7 +83,7 @@ require_once __DIR__ . '/../partials/header.php';
     <form id="bulk-action-form" action="delete_messages_handler.php" method="post">
         <!-- Kirim chat_id karena ini bukan halaman user-specific -->
         <input type="hidden" name="chat_id" value="<?= $chat_id ?>">
-        <input type="hidden" name="bot_id" value="<?= $telegram_bot_id ?>">
+        <input type="hidden" name="bot_id" value="<?= $bot_id ?>">
         <input type="hidden" name="source_page" value="channel_chat">
 
 

--- a/admin/delete_messages_handler.php
+++ b/admin/delete_messages_handler.php
@@ -20,7 +20,7 @@ if (!$pdo) {
 // Ambil data dari form
 $message_ids = $_POST['message_ids'] ?? [];
 $action = $_POST['action'] ?? '';
-$telegram_bot_id = isset($_POST['bot_id']) ? (int)$_POST['bot_id'] : 0; // This now holds telegram_bot_id
+$bot_id = isset($_POST['bot_id']) ? (int)$_POST['bot_id'] : 0;
 
 // Logika untuk menangani sumber halaman yang berbeda (user chat vs channel chat)
 $telegram_id = isset($_POST['user_id']) ? (int)$_POST['user_id'] : 0; // This now holds telegram_id
@@ -29,11 +29,11 @@ $source_page = $_POST['source_page'] ?? 'user_chat';
 
 // Tentukan URL redirect berdasarkan sumber
 if ($source_page === 'channel_chat') {
-    $redirect_url = "channel_chat.php?chat_id=$chat_id_param&bot_id=$telegram_bot_id";
-    $is_valid = !empty($message_ids) && is_array($message_ids) && !empty($action) && $chat_id_param && $telegram_bot_id;
+    $redirect_url = "channel_chat.php?chat_id=$chat_id_param&bot_id=$bot_id";
+    $is_valid = !empty($message_ids) && is_array($message_ids) && !empty($action) && $chat_id_param && $bot_id;
 } else {
-    $redirect_url = "chat.php?telegram_id=$telegram_id&bot_id=$telegram_bot_id";
-    $is_valid = !empty($message_ids) && is_array($message_ids) && !empty($action) && $telegram_id && $telegram_bot_id;
+    $redirect_url = "chat.php?telegram_id=$telegram_id&bot_id=$bot_id";
+    $is_valid = !empty($message_ids) && is_array($message_ids) && !empty($action) && $telegram_id && $bot_id;
 }
 
 // Validasi input
@@ -43,8 +43,8 @@ if (!$is_valid) {
 }
 
 // Ambil info bot untuk inisialisasi API
-$stmt_bot = $pdo->prepare("SELECT token FROM bots WHERE telegram_bot_id = ?");
-$stmt_bot->execute([$telegram_bot_id]);
+$stmt_bot = $pdo->prepare("SELECT token FROM bots WHERE id = ?");
+$stmt_bot->execute([$bot_id]);
 $bot_info = $stmt_bot->fetch();
 
 if (!$bot_info) {

--- a/admin/edit_bot.php
+++ b/admin/edit_bot.php
@@ -22,11 +22,11 @@ if (!isset($_GET['id']) || !filter_var($_GET['id'], FILTER_VALIDATE_INT)) {
     header("Location: bots.php");
     exit;
 }
-$telegram_bot_id = $_GET['id'];
+$bot_id = $_GET['id'];
 
 // Ambil data bot dari database menggunakan ID Telegram-nya.
-$stmt = $pdo->prepare("SELECT telegram_bot_id, first_name, username, token, created_at FROM bots WHERE telegram_bot_id = ?");
-$stmt->execute([$telegram_bot_id]);
+$stmt = $pdo->prepare("SELECT id, first_name, username, token, created_at FROM bots WHERE id = ?");
+$stmt->execute([$bot_id]);
 $bot = $stmt->fetch();
 
 // Jika bot tidak ditemukan, alihkan kembali ke halaman daftar bot.
@@ -37,7 +37,7 @@ if (!$bot) {
 
 // Ambil pengaturan spesifik untuk bot ini dari tabel `bot_settings`.
 $stmt_settings = $pdo->prepare("SELECT setting_key, setting_value FROM bot_settings WHERE bot_id = ?");
-$stmt_settings->execute([$telegram_bot_id]);
+$stmt_settings->execute([$bot_id]);
 $bot_settings_raw = $stmt_settings->fetchAll(PDO::FETCH_KEY_PAIR);
 
 // Tetapkan nilai default untuk setiap pengaturan jika belum ada di database,
@@ -75,7 +75,7 @@ require_once __DIR__ . '/../partials/header.php';
 
         <div class="bot-info">
             <h2>Informasi Bot</h2>
-            <p><strong>ID Telegram:</strong> <?= htmlspecialchars($bot['telegram_bot_id']) ?></p>
+            <p><strong>ID Telegram:</strong> <?= htmlspecialchars($bot['id']) ?></p>
             <p><strong>Nama Depan:</strong> <?= htmlspecialchars($bot['first_name']) ?></p>
             <p><strong>Username:</strong> @<?= htmlspecialchars($bot['username'] ?? 'N/A') ?></p>
             <p><strong>Token:</strong> <code><?= substr(htmlspecialchars($bot['token']), 0, 15) ?>...</code></p>
@@ -84,19 +84,18 @@ require_once __DIR__ . '/../partials/header.php';
 
         <div class="actions">
             <h2>Manajemen Bot & Webhook</h2>
-            <button class="set-webhook" data-bot-id="<?= $bot['telegram_bot_id'] ?>">Set Webhook</button>
-            <button class="check-webhook" data-bot-id="<?= $bot['telegram_bot_id'] ?>">Check Webhook</button>
-            <button class="delete-webhook" data-bot-id="<?= $bot['telegram_bot_id'] ?>">Delete Webhook</button>
-            <button class="test-webhook" data-telegram-bot-id="<?= htmlspecialchars($bot['telegram_bot_id']) ?>" title="Kirim POST request kosong untuk memeriksa apakah webhook merespons 200 OK">Test Webhook</button>
-            <button class="get-me" data-bot-id="<?= $bot['telegram_bot_id'] ?>">Get Me & Update</button>
+            <button class="set-webhook" data-bot-id="<?= $bot['id'] ?>">Set Webhook</button>
+            <button class="check-webhook" data-bot-id="<?= $bot['id'] ?>">Check Webhook</button>
+            <button class="delete-webhook" data-bot-id="<?= $bot['id'] ?>">Delete Webhook</button>
+            <button class="test-webhook" data-telegram-bot-id="<?= htmlspecialchars($bot['id']) ?>" title="Kirim POST request kosong untuk memeriksa apakah webhook merespons 200 OK">Test Webhook</button>
+            <button class="get-me" data-bot-id="<?= $bot['id'] ?>">Get Me & Update</button>
         </div>
 
         <div class="settings">
             <h2>Pengaturan Penyimpanan Pesan</h2>
             <p>Pilih jenis pembaruan (update) dari Telegram yang ingin Anda simpan ke database untuk bot ini.</p>
             <form action="settings_manager.php" method="post">
-                <input type="hidden" name="bot_id" value="<?= $bot['telegram_bot_id'] ?>">
-                <input type="hidden" name="telegram_bot_id" value="<?= htmlspecialchars($bot['telegram_bot_id']) ?>">
+                <input type="hidden" name="bot_id" value="<?= $bot['id'] ?>">
 
                 <div class="setting-item">
                     <label>
@@ -196,12 +195,12 @@ require_once __DIR__ . '/../partials/header.php';
 
         /**
          * Menangani aksi pengujian webhook dengan mengirimkan POST request kosong ke URL webhook.
-         * @param {number} telegramBotId - ID Telegram dari bot.
+         * @param {number} botId - ID Telegram dari bot.
          */
-        async function handleTestWebhook(telegramBotId) {
+        async function handleTestWebhook(botId) {
             // Ambil BASE_URL dari config, jika tidak ada, coba tebak dari URL saat ini
             const baseUrl = '<?= defined('BASE_URL') && BASE_URL ? rtrim(BASE_URL, '/') : (isset($_SERVER['HTTPS']) ? 'https' : 'http') . '://' . $_SERVER['HTTP_HOST'] ?>';
-            const webhookUrl = `${baseUrl}/webhook.php?id=${telegramBotId}`;
+            const webhookUrl = `${baseUrl}/webhook.php?id=${botId}`;
 
             showModal('Hasil Test POST', `Mengirim request ke:\n${webhookUrl}\n\nMohon tunggu...`);
 

--- a/admin/index.php
+++ b/admin/index.php
@@ -51,25 +51,25 @@ try {
 }
 
 // Ambil semua bot untuk sidebar
-$bots = $pdo->query("SELECT telegram_bot_id, first_name FROM bots ORDER BY first_name ASC")->fetchAll();
+$bots = $pdo->query("SELECT id, first_name FROM bots ORDER BY first_name ASC")->fetchAll();
 
 // Dapatkan parameter dari URL
-$selected_telegram_bot_id = isset($_GET['bot_id']) ? (int)$_GET['bot_id'] : null;
+$selected_bot_id = isset($_GET['bot_id']) ? (int)$_GET['bot_id'] : null;
 $search_user = trim($_GET['search_user'] ?? '');
 
 $conversations = [];
 $channel_chats = [];
 $bot_exists = false;
 
-if ($selected_telegram_bot_id) {
+if ($selected_bot_id) {
     // Verifikasi bot ada
-    $stmt = $pdo->prepare("SELECT 1 FROM bots WHERE telegram_bot_id = ?");
-    $stmt->execute([$selected_telegram_bot_id]);
+    $stmt = $pdo->prepare("SELECT 1 FROM bots WHERE id = ?");
+    $stmt->execute([$selected_bot_id]);
     $bot_exists = $stmt->fetchColumn();
 
     if ($bot_exists) {
         // --- Ambil percakapan PRIBADI ---
-        $params = [$selected_telegram_bot_id];
+        $params = [$selected_bot_id];
         $user_where_clause = '';
         if (!empty($search_user)) {
             $user_where_clause = "AND (u.first_name LIKE ? OR u.last_name LIKE ? OR u.username LIKE ? OR u.telegram_id = ?)";
@@ -99,7 +99,7 @@ if ($selected_telegram_bot_id) {
                 FROM messages m
                 WHERE m.bot_id = ? AND m.chat_id < 0 ORDER BY last_message_time DESC"
             );
-            $stmt_channels->execute([$selected_telegram_bot_id]);
+            $stmt_channels->execute([$selected_bot_id]);
             $channel_chats = $stmt_channels->fetchAll();
         }
     }
@@ -120,12 +120,12 @@ require_once __DIR__ . '/../partials/header.php';
             <?php else: ?>
                 <?php foreach ($bots as $bot): ?>
                     <?php
-                        $link_params = ['bot_id' => $bot['telegram_bot_id']];
+                        $link_params = ['bot_id' => $bot['id']];
                         if (!empty($search_user)) {
                             $link_params['search_user'] = $search_user;
                         }
                     ?>
-                    <a href="index.php?<?= http_build_query($link_params) ?>" class="<?= ($selected_telegram_bot_id == $bot['telegram_bot_id']) ? 'active' : '' ?>">
+                    <a href="index.php?<?= http_build_query($link_params) ?>" class="<?= ($selected_bot_id == $bot['id']) ? 'active' : '' ?>">
                         <?= htmlspecialchars($bot['first_name'] ?? 'Bot Tanpa Nama') ?>
                     </a>
                 <?php endforeach; ?>
@@ -136,20 +136,20 @@ require_once __DIR__ . '/../partials/header.php';
     <main class="conv-main">
         <div class="search-form" style="margin-bottom: 20px;">
             <form action="index.php" method="get">
-                <?php if ($selected_telegram_bot_id): ?>
-                    <input type="hidden" name="bot_id" value="<?= htmlspecialchars($selected_telegram_bot_id) ?>">
+                <?php if ($selected_bot_id): ?>
+                    <input type="hidden" name="bot_id" value="<?= htmlspecialchars($selected_bot_id) ?>">
                 <?php endif; ?>
                 <input type="text" name="search_user" placeholder="Cari percakapan pengguna..." value="<?= htmlspecialchars($search_user) ?>" style="width: 300px; display: inline-block;">
                 <button type="submit" class="btn">Cari</button>
                 <?php if(!empty($search_user)): ?>
-                    <a href="index.php?bot_id=<?= $selected_telegram_bot_id ?>" class="btn btn-delete">Hapus Filter</a>
+                    <a href="index.php?bot_id=<?= $selected_bot_id ?>" class="btn btn-delete">Hapus Filter</a>
                 <?php endif; ?>
             </form>
         </div>
 
-        <?php if ($selected_telegram_bot_id): ?>
+        <?php if ($selected_bot_id): ?>
             <?php if (!$bot_exists): ?>
-                <div class="alert alert-danger">Bot dengan ID <?= htmlspecialchars($selected_telegram_bot_id) ?> tidak ditemukan.</div>
+                <div class="alert alert-danger">Bot dengan ID <?= htmlspecialchars($selected_bot_id) ?> tidak ditemukan.</div>
             <?php else: ?>
 
                 <h3>Percakapan Pengguna</h3>
@@ -159,7 +159,7 @@ require_once __DIR__ . '/../partials/header.php';
                     <?php else: ?>
                         <?php foreach ($conversations as $conv): ?>
                             <li class="conv-card">
-                                <a href="chat.php?telegram_id=<?= $conv['telegram_id'] ?>&bot_id=<?= $selected_telegram_bot_id ?>">
+                                <a href="chat.php?telegram_id=<?= $conv['telegram_id'] ?>&bot_id=<?= $selected_bot_id ?>">
                                     <div class="conv-avatar"><?= get_initials($conv['first_name'] ?? '?') ?></div>
                                     <div class="conv-details">
                                         <div class="conv-header">
@@ -189,7 +189,7 @@ require_once __DIR__ . '/../partials/header.php';
                                 }
                             ?>
                             <li class="conv-card">
-                                <a href="channel_chat.php?chat_id=<?= $chat['chat_id'] ?>&bot_id=<?= $selected_telegram_bot_id ?>">
+                                <a href="channel_chat.php?chat_id=<?= $chat['chat_id'] ?>&bot_id=<?= $selected_bot_id ?>">
                                     <div class="conv-avatar" style="background-color: #6c757d;"><?= get_initials($chat_title) ?></div>
                                     <div class="conv-details">
                                         <div class="conv-header">

--- a/admin/settings_manager.php
+++ b/admin/settings_manager.php
@@ -27,10 +27,9 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 
 // Validasi input
 $bot_id = filter_input(INPUT_POST, 'bot_id', FILTER_VALIDATE_INT);
-$telegram_bot_id = filter_input(INPUT_POST, 'telegram_bot_id', FILTER_VALIDATE_INT);
 $settings_from_form = $_POST['settings'] ?? [];
 
-if (!$bot_id || !$telegram_bot_id) {
+if (!$bot_id) {
     // Jika ID tidak valid, kembali ke daftar bot utama
     $_SESSION['status_message'] = 'Error: ID Bot tidak valid.';
     header('Location: bots.php');
@@ -38,7 +37,7 @@ if (!$bot_id || !$telegram_bot_id) {
 }
 
 // Redirect kembali ke halaman edit bot jika terjadi error
-$redirect_url = "edit_bot.php?id=" . $telegram_bot_id;
+$redirect_url = "edit_bot.php?id=" . $bot_id;
 
 $pdo = get_db_connection();
 if (!$pdo) {

--- a/admin/users.php
+++ b/admin/users.php
@@ -18,7 +18,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
     // Aksi untuk mengubah status blokir
     if ($_POST['action'] === 'toggle_block') {
         $telegram_id_to_toggle = (int)($_POST['user_id'] ?? 0); // Still user_id from form, but holds telegram_id
-        $bot_id_to_toggle = (int)($_POST['bot_id'] ?? 0); // This should be telegram_bot_id
+        $bot_id_to_toggle = (int)($_POST['bot_id'] ?? 0);
         if ($telegram_id_to_toggle && $bot_id_to_toggle) {
             $stmt = $pdo->prepare("SELECT is_blocked FROM rel_user_bot WHERE user_id = ? AND bot_id = ?");
             $stmt->execute([$telegram_id_to_toggle, $bot_id_to_toggle]);

--- a/admin/webhook_manager.php
+++ b/admin/webhook_manager.php
@@ -17,9 +17,9 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_POST['action']) || !isset(
 }
 
 $action = $_POST['action'];
-$telegram_bot_id = filter_var($_POST['bot_id'], FILTER_VALIDATE_INT); // This field now contains the telegram_bot_id
+$bot_id = filter_var($_POST['bot_id'], FILTER_VALIDATE_INT);
 
-if (!$telegram_bot_id) {
+if (!$bot_id) {
     json_response('error', 'ID Bot tidak valid.');
 }
 
@@ -29,12 +29,12 @@ if (!$pdo) {
     json_response('error', 'Koneksi database gagal.');
 }
 
-$stmt = $pdo->prepare("SELECT token FROM bots WHERE telegram_bot_id = ?");
-$stmt->execute([$telegram_bot_id]);
+$stmt = $pdo->prepare("SELECT token FROM bots WHERE id = ?");
+$stmt->execute([$bot_id]);
 $bot = $stmt->fetch();
 
 if (!$bot) {
-    json_response('error', "Bot dengan ID Telegram {$telegram_bot_id} tidak ditemukan.");
+    json_response('error', "Bot dengan ID Telegram {$bot_id} tidak ditemukan.");
 }
 $bot_token = $bot['token'];
 
@@ -51,7 +51,7 @@ try {
             $domain = $_SERVER['HTTP_HOST'];
             // Buat path relatif yang benar dari /admin/ ke /webhook.php
             $webhook_path = str_replace('/admin', '', dirname($_SERVER['PHP_SELF'])) . '/webhook.php';
-            $webhook_url = $protocol . $domain . $webhook_path . '?id=' . $telegram_bot_id;
+            $webhook_url = $protocol . $domain . $webhook_path . '?id=' . $bot_id;
 
             $result = $telegram->setWebhook($webhook_url);
             break;

--- a/core/UpdateDispatcher.php
+++ b/core/UpdateDispatcher.php
@@ -25,7 +25,6 @@ class UpdateDispatcher
     private $update_handler;
     private $telegram_api;
     private $bot_settings;
-    private $telegram_bot_id;
 
     public function __construct(PDO $pdo, array $bot, array $update)
     {
@@ -38,9 +37,7 @@ class UpdateDispatcher
 
         $this->update_handler = new UpdateHandler($this->bot_settings);
 
-        // Ekstrak dan simpan telegram_bot_id untuk penggunaan konsisten
-        $this->telegram_bot_id = (int)explode(':', $bot['token'])[0];
-        $this->telegram_api = new TelegramAPI($bot['token'], $pdo, $this->telegram_bot_id);
+        $this->telegram_api = new TelegramAPI($bot['token'], $pdo, (int)$bot['id']);
     }
 
     public function dispatch()
@@ -80,7 +77,7 @@ class UpdateDispatcher
             $current_user = null;
 
             if ($user_id) {
-                $user_repo = new UserRepository($this->pdo, $this->telegram_bot_id);
+                $user_repo = new UserRepository($this->pdo, (int)$this->bot['id']);
                 $current_user = $user_repo->findOrCreateUser(
                     $user_id,
                     $message_context['from']['first_name'] ?? '',

--- a/core/database/BotRepository.php
+++ b/core/database/BotRepository.php
@@ -20,14 +20,14 @@ class BotRepository
     /**
      * Mencari bot berdasarkan ID Telegram-nya dan mengembalikan data bot.
      *
-     * @param int $telegram_bot_id ID numerik bot di Telegram.
+     * @param int $bot_id ID numerik bot di Telegram.
      * @return array|false Mengembalikan data bot sebagai array asosiatif jika ditemukan, atau `false` jika tidak.
      */
-    public function findBotByTelegramId(int $telegram_bot_id)
+    public function findBotByTelegramId(int $bot_id)
     {
         // Bot sekarang dicari berdasarkan ID Telegram-nya, yang merupakan Primary Key.
         $stmt = $this->pdo->prepare("SELECT id, token FROM bots WHERE id = ?");
-        $stmt->execute([$telegram_bot_id]);
+        $stmt->execute([$bot_id]);
         return $stmt->fetch(PDO::FETCH_ASSOC);
     }
 

--- a/core/database/PackageRepository.php
+++ b/core/database/PackageRepository.php
@@ -314,13 +314,13 @@ class PackageRepository
      * Sebaiknya dijalankan di dalam sebuah transaksi.
      *
      * @param int $seller_telegram_id ID Telegram penjual.
-     * @param int $telegram_bot_id ID Telegram bot yang digunakan untuk membuat paket.
+     * @param int $bot_id ID Telegram bot yang digunakan untuk membuat paket.
      * @param string $description Deskripsi paket.
      * @param int $thumbnail_media_id ID internal dari file media yang dijadikan thumbnail.
      * @return int ID internal dari paket yang baru dibuat.
      * @throws Exception Jika terjadi kegagalan dalam transaksi atau jika penjual tidak valid.
      */
-    public function createPackageWithPublicId(int $seller_telegram_id, int $telegram_bot_id, string $description, int $thumbnail_media_id): int
+    public function createPackageWithPublicId(int $seller_telegram_id, int $bot_id, string $description, int $thumbnail_media_id): int
     {
         try {
             // 1. Ambil dan kunci baris pengguna untuk mendapatkan urutan & ID publik
@@ -346,7 +346,7 @@ class PackageRepository
                 "INSERT INTO media_packages (seller_user_id, bot_id, description, thumbnail_media_id, status, public_id)
                  VALUES (?, ?, ?, ?, 'pending', ?)"
             );
-            $stmt_package->execute([$seller_telegram_id, $telegram_bot_id, $description, $thumbnail_media_id, $public_id]);
+            $stmt_package->execute([$seller_telegram_id, $bot_id, $description, $thumbnail_media_id, $public_id]);
             $package_id = $this->pdo->lastInsertId();
 
             return $package_id;

--- a/core/database/SellerSalesChannelRepository.php
+++ b/core/database/SellerSalesChannelRepository.php
@@ -23,12 +23,12 @@ class SellerSalesChannelRepository
      * Jika penjual sudah punya channel, detailnya akan diperbarui dan diaktifkan kembali.
      *
      * @param int $seller_telegram_id ID Telegram pengguna (penjual).
-     * @param int $telegram_bot_id ID Telegram bot yang akan dihubungkan.
+     * @param int $bot_id ID Telegram bot yang akan dihubungkan.
      * @param int $channel_id ID channel Telegram.
      * @param int $discussion_group_id ID grup diskusi yang terhubung.
      * @return bool True jika berhasil.
      */
-    public function createOrUpdate(int $seller_telegram_id, int $telegram_bot_id, int $channel_id, int $discussion_group_id): bool
+    public function createOrUpdate(int $seller_telegram_id, int $bot_id, int $channel_id, int $discussion_group_id): bool
     {
         // Menggunakan ON DUPLICATE KEY UPDATE yang bergantung pada kunci unik di seller_user_id
         $sql = "INSERT INTO seller_sales_channels (seller_user_id, bot_id, channel_id, discussion_group_id, is_active)
@@ -36,7 +36,7 @@ class SellerSalesChannelRepository
                 ON DUPLICATE KEY UPDATE bot_id = VALUES(bot_id), channel_id = VALUES(channel_id), discussion_group_id = VALUES(discussion_group_id), is_active = 1";
 
         $stmt = $this->pdo->prepare($sql);
-        return $stmt->execute([$seller_telegram_id, $telegram_bot_id, $channel_id, $discussion_group_id]);
+        return $stmt->execute([$seller_telegram_id, $bot_id, $channel_id, $discussion_group_id]);
     }
 
     /**

--- a/core/database/UserRepository.php
+++ b/core/database/UserRepository.php
@@ -7,18 +7,18 @@
 class UserRepository
 {
     private $pdo;
-    private $telegram_bot_id;
+    private $bot_id;
 
     /**
      * Membuat instance UserRepository.
      *
      * @param PDO $pdo Objek koneksi database.
-     * @param int $telegram_bot_id ID Telegram bot yang sedang berinteraksi dengan pengguna.
+     * @param int $bot_id ID Telegram bot yang sedang berinteraksi dengan pengguna.
      */
-    public function __construct(PDO $pdo, int $telegram_bot_id)
+    public function __construct(PDO $pdo, int $bot_id)
     {
         $this->pdo = $pdo;
-        $this->telegram_bot_id = $telegram_bot_id;
+        $this->bot_id = $bot_id;
     }
 
     /**
@@ -88,7 +88,7 @@ class UserRepository
 
         // Pastikan relasi user-bot ada (gunakan INSERT IGNORE untuk efisiensi)
         $this->pdo->prepare("INSERT IGNORE INTO rel_user_bot (user_id, bot_id) VALUES (?, ?)")
-                  ->execute([$telegram_user_id, $this->telegram_bot_id]);
+                  ->execute([$telegram_user_id, $this->bot_id]);
 
         // Entri member tidak lagi diperlukan karena tabelnya digabungkan.
 
@@ -117,7 +117,7 @@ class UserRepository
              WHERE u.id = ?
              LIMIT 1"
         );
-        $stmt_user->execute([$this->telegram_bot_id, $telegram_user_id]);
+        $stmt_user->execute([$this->bot_id, $telegram_user_id]);
         return $stmt_user->fetch(PDO::FETCH_ASSOC);
     }
 
@@ -133,7 +133,7 @@ class UserRepository
     public function setUserState(int $telegram_user_id, ?string $state, ?array $context = null)
     {
         $stmt = $this->pdo->prepare("UPDATE rel_user_bot SET state = ?, state_context = ? WHERE user_id = ? AND bot_id = ?");
-        $stmt->execute([$state, $context ? json_encode($context) : null, $telegram_user_id, $this->telegram_bot_id]);
+        $stmt->execute([$state, $context ? json_encode($context) : null, $telegram_user_id, $this->bot_id]);
     }
 
     /**
@@ -141,9 +141,9 @@ class UserRepository
      *
      * @return int ID Telegram bot.
      */
-    public function getTelegramBotId(): int
+    public function getBotId(): int
     {
-        return $this->telegram_bot_id;
+        return $this->bot_id;
     }
 
     /**

--- a/core/handlers/CallbackQueryHandler.php
+++ b/core/handlers/CallbackQueryHandler.php
@@ -158,7 +158,7 @@ class CallbackQueryHandler implements HandlerInterface
      */
     private function handleRegisterSeller(App $app, array $callback_query)
     {
-        $user_repo = new UserRepository($app->pdo, $app->bot['telegram_bot_id']);
+        $user_repo = new UserRepository($app->pdo, $app->bot['id']);
 
         if (!empty($app->user['public_seller_id'])) {
             $app->telegram_api->answerCallbackQuery($callback_query['id'], 'Anda sudah terdaftar sebagai penjual.', true);

--- a/core/handlers/ChannelPostHandler.php
+++ b/core/handlers/ChannelPostHandler.php
@@ -32,7 +32,7 @@ class ChannelPostHandler implements HandlerInterface
              VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, 'incoming', ?)"
         );
         $stmt->execute([
-            $app->bot['telegram_bot_id'],
+            $app->bot['id'],
             $telegram_message_id,
             $chat_id,
             $chat_type,

--- a/core/handlers/MessageHandler.php
+++ b/core/handlers/MessageHandler.php
@@ -86,7 +86,7 @@ class MessageHandler implements HandlerInterface
      */
     private function handleState(App $app, array $message): void
     {
-        $user_repo = new UserRepository($app->pdo, $app->bot['telegram_bot_id']);
+        $user_repo = new UserRepository($app->pdo, $app->bot['id']);
         $text = $message['text'];
         $state_context = json_decode($app->user['state_context'] ?? '{}', true);
 
@@ -303,7 +303,7 @@ EOT;
      */
     private function handleSellCommand(App $app, array $message)
     {
-        $user_repo = new UserRepository($app->pdo, $app->bot['telegram_bot_id']);
+        $user_repo = new UserRepository($app->pdo, $app->bot['id']);
 
         if (!isset($message['reply_to_message'])) {
             $app->telegram_api->sendMessage($app->chat_id, "Untuk menjual, silakan reply media yang ingin Anda jual dengan perintah /sell.");
@@ -478,7 +478,7 @@ EOT;
      */
     private function addMediaToNewPackage(App $app, array $message)
     {
-        $user_repo = new UserRepository($app->pdo, $app->bot['telegram_bot_id']);
+        $user_repo = new UserRepository($app->pdo, $app->bot['id']);
 
         if ($app->user['state'] !== 'awaiting_price') {
             $app->telegram_api->sendMessage($app->chat_id, "⚠️ Perintah ini hanya bisa digunakan saat Anda sedang dalam proses menjual item.");

--- a/migrations/035_switch_to_telegram_ids.php
+++ b/migrations/035_switch_to_telegram_ids.php
@@ -1,15 +1,26 @@
 <?php
 
 /**
- * Migrasi 035: Beralih dari ID internal ke ID Telegram sebagai Primary Key.
+ * MIGRATION 035: DISABLED.
  *
- * Perubahan Skema:
- * 1.  Menambahkan `telegram_bot_id` ke tabel `bots` dan mengisinya dari token.
- * 2.  Mengubah semua kolom `user_id` dan `bot_id` di tabel terkait menjadi BIGINT.
- * 3.  Mengganti nilai `user_id` dan `bot_id` internal dengan `telegram_id` dan `telegram_bot_id`.
- * 4.  Mengubah Primary Key di `users` dari `id` menjadi `telegram_id`.
- * 5.  Mengubah Primary Key di `bots` dari `id` menjadi `telegram_bot_id`.
- * 6.  Membuat ulang semua Foreign Key yang relevan.
+ * This migration was intended to switch the primary key of the `bots` table
+ * from an internal auto-incrementing `id` to the `telegram_bot_id`.
+ *
+ * However, the final database schema as seen in `updated_schema.sql` reflects a different outcome:
+ * - The primary key for the `bots` table is still named `id`.
+ * - This `id` column was changed to a BIGINT to store the Telegram Bot ID directly.
+ *
+ * This migration script is therefore inconsistent with the final state of the database
+ * and represents an abandoned or altered refactoring path.
+ *
+ * Running this script would corrupt the database by attempting to add a redundant
+ * `telegram_bot_id` column and incorrectly altering primary and foreign keys.
+ *
+ * To prevent accidental execution and to document this historical inconsistency,
+ * the logic of this migration has been disabled.
+ *
+ * Original Author: Jules (AI)
+ * Date: 2025-08-27
  */
 
 if (php_sapi_name() !== 'cli') {
@@ -18,8 +29,6 @@ if (php_sapi_name() !== 'cli') {
 
 require_once __DIR__ . '/../core/database.php';
 
-// Jika skrip ini di-include oleh runner lain, $pdo sudah harus ada.
-// Jika tidak, buat koneksi baru untuk eksekusi mandiri.
 if (!isset($pdo)) {
     $pdo = get_db_connection();
     if (!$pdo) {
@@ -27,42 +36,7 @@ if (!isset($pdo)) {
     }
 }
 
-// Tentukan apakah skrip ini perlu mengelola transaksinya sendiri.
 $is_managing_transaction = !$pdo->inTransaction();
-
-// Daftar tabel yang memiliki foreign key ke `users` atau `bots`
-// dan nama constraint-nya. Ini mungkin perlu disesuaikan.
-$constraints_to_rebuild = [
-    'rel_user_bot' => [
-        ['name' => 'rel_user_bot_ibfk_1', 'col' => 'user_id', 'ref_table' => 'users', 'ref_col' => 'telegram_id'],
-        ['name' => 'rel_user_bot_ibfk_2', 'col' => 'bot_id', 'ref_table' => 'bots', 'ref_col' => 'telegram_bot_id']
-    ],
-    'messages' => [
-        ['name' => 'messages_ibfk_1', 'col' => 'user_id', 'ref_table' => 'users', 'ref_col' => 'telegram_id'],
-        ['name' => 'messages_ibfk_2', 'col' => 'bot_id', 'ref_table' => 'bots', 'ref_col' => 'telegram_bot_id']
-    ],
-    'members' => [
-        ['name' => 'fk_members_user_id', 'col' => 'user_id', 'ref_table' => 'users', 'ref_col' => 'telegram_id']
-    ],
-    'bot_settings' => [
-        ['name' => 'bot_settings_ibfk_1', 'col' => 'bot_id', 'ref_table' => 'bots', 'ref_col' => 'telegram_bot_id']
-    ],
-    'seller_sales_channels' => [
-        // Nama constraint dan kolom disesuaikan dengan skema asli
-        ['name' => 'fk_seller_sales_channels_user_id', 'col' => 'seller_user_id', 'ref_table' => 'users', 'ref_col' => 'telegram_id'],
-        ['name' => 'seller_sales_channels_ibfk_2', 'col' => 'bot_id', 'ref_table' => 'bots', 'ref_col' => 'telegram_bot_id']
-    ],
-    // 'channel_post_packages' tidak memiliki bot_id, jadi foreign key tidak perlu dibuat ulang untuk bot.
-    'balance_transactions' => [
-        ['name' => 'balance_transactions_ibfk_1', 'col' => 'user_id', 'ref_table' => 'users', 'ref_col' => 'telegram_id']
-    ],
-    'sales' => [
-        // Asumsi nama constraint, mungkin perlu verifikasi
-        ['name' => 'sales_ibfk_1', 'col' => 'seller_user_id', 'ref_table' => 'users', 'ref_col' => 'telegram_id'],
-        ['name' => 'sales_ibfk_2', 'col' => 'buyer_user_id', 'ref_table' => 'users', 'ref_col' => 'telegram_id'],
-    ]
-    // Tambahkan tabel lain jika ada
-];
 
 if ($is_managing_transaction) {
     $pdo->beginTransaction();
@@ -70,99 +44,14 @@ if ($is_managing_transaction) {
 }
 
 try {
-    // 1. Tambah dan isi `telegram_bot_id` di tabel `bots`
-    echo "1. Altering `bots` table..." . PHP_EOL;
-    try {
-        $pdo->exec("ALTER TABLE `bots` ADD COLUMN `telegram_bot_id` BIGINT NULL UNIQUE AFTER `id`;");
-    } catch (PDOException $e) {
-        // SQLSTATE 42S21 adalah error untuk 'Duplicate column name'
-        if ($e->getCode() === '42S21') {
-            echo "   Warning: Column 'telegram_bot_id' already exists. Skipping 'ADD COLUMN'." . PHP_EOL;
-        } else {
-            throw $e; // Lemparkan kembali error lain yang tidak terduga
-        }
-    }
-    $pdo->exec("UPDATE `bots` SET `telegram_bot_id` = CAST(SUBSTRING_INDEX(`token`, ':', 1) AS UNSIGNED);");
-
-    // Validasi
-    $stmt = $pdo->query("SELECT COUNT(*) FROM `bots` WHERE `telegram_bot_id` IS NULL;");
-    if ($stmt->fetchColumn() > 0) {
-        throw new Exception("Found bots with NULL telegram_bot_id. Migration cannot continue.");
-    }
-    echo "   `bots` table altered and populated successfully." . PHP_EOL;
-
-    // 2. Drop Foreign Keys
-    echo "2. Dropping foreign keys..." . PHP_EOL;
-    foreach ($constraints_to_rebuild as $table => $constraints) {
-        foreach ($constraints as $constraint) {
-            try {
-                $pdo->exec("ALTER TABLE `$table` DROP FOREIGN KEY `{$constraint['name']}`;");
-                echo "   Dropped FK `{$constraint['name']}` from `$table`." . PHP_EOL;
-            } catch (PDOException $e) {
-                echo "   Warning: Could not drop FK `{$constraint['name']}` from `$table`. It might not exist. Error: " . $e->getMessage() . PHP_EOL;
-            }
-        }
-    }
-
-    // 3. Update data di tabel anak
-    echo "3. Updating foreign key columns data..." . PHP_EOL;
-    $pdo->exec("UPDATE `rel_user_bot` ru JOIN `users` u ON ru.user_id = u.id SET ru.user_id = u.telegram_id;");
-    $pdo->exec("UPDATE `rel_user_bot` ru JOIN `bots` b ON ru.bot_id = b.id SET ru.bot_id = b.telegram_bot_id;");
-    $pdo->exec("UPDATE `messages` m JOIN `users` u ON m.user_id = u.id SET m.user_id = u.telegram_id;");
-    $pdo->exec("UPDATE `messages` m JOIN `bots` b ON m.bot_id = b.id SET m.bot_id = b.telegram_bot_id;");
-    $pdo->exec("UPDATE `members` m JOIN `users` u ON m.user_id = u.id SET m.user_id = u.telegram_id;");
-    $pdo->exec("UPDATE `bot_settings` bs JOIN `bots` b ON bs.bot_id = b.id SET bs.bot_id = b.telegram_bot_id;");
-    $pdo->exec("UPDATE `seller_sales_channels` ssc JOIN `users` u ON ssc.seller_user_id = u.id SET ssc.seller_user_id = u.telegram_id;");
-    $pdo->exec("UPDATE `seller_sales_channels` ssc JOIN `bots` b ON ssc.bot_id = b.id SET ssc.bot_id = b.telegram_bot_id;");
-    // Baris berikut dihapus karena tabel channel_post_packages tidak memiliki kolom bot_id
-    // $pdo->exec("UPDATE `channel_post_packages` cpp JOIN `bots` b ON cpp.bot_id = b.id SET cpp.bot_id = b.telegram_bot_id;");
-    $pdo->exec("UPDATE `balance_transactions` bt JOIN `users` u ON bt.user_id = u.id SET bt.user_id = u.telegram_id;");
-    $pdo->exec("UPDATE `sales` s JOIN `users` u_seller ON s.seller_user_id = u_seller.id SET s.seller_user_id = u_seller.telegram_id;");
-    $pdo->exec("UPDATE `sales` s JOIN `users` u_buyer ON s.buyer_user_id = u_buyer.id SET s.buyer_user_id = u_buyer.telegram_id;");
-    echo "   Data updated successfully." . PHP_EOL;
-
-    // 4. Ubah tipe kolom
-    echo "4. Changing column types to BIGINT..." . PHP_EOL;
-    $pdo->exec("ALTER TABLE `rel_user_bot` MODIFY `user_id` BIGINT NOT NULL, MODIFY `bot_id` BIGINT NOT NULL;");
-    $pdo->exec("ALTER TABLE `messages` MODIFY `user_id` BIGINT NULL, MODIFY `bot_id` BIGINT NOT NULL;"); // User ID can be null
-    $pdo->exec("ALTER TABLE `members` MODIFY `user_id` BIGINT NOT NULL;");
-    $pdo->exec("ALTER TABLE `bot_settings` MODIFY `bot_id` BIGINT NOT NULL;");
-    $pdo->exec("ALTER TABLE `seller_sales_channels` MODIFY `seller_user_id` BIGINT NOT NULL, MODIFY `bot_id` BIGINT NOT NULL;");
-    // Baris berikut dihapus karena tabel channel_post_packages tidak memiliki kolom bot_id
-    // $pdo->exec("ALTER TABLE `channel_post_packages` MODIFY `bot_id` BIGINT NOT NULL;");
-    $pdo->exec("ALTER TABLE `balance_transactions` MODIFY `user_id` BIGINT NOT NULL;");
-    $pdo->exec("ALTER TABLE `sales` MODIFY `seller_user_id` BIGINT NOT NULL, MODIFY `buyer_user_id` BIGINT NOT NULL;");
-    echo "   Column types changed." . PHP_EOL;
-
-    // 5. Ubah Primary Keys
-    echo "5. Changing primary keys..." . PHP_EOL;
-    // Users
-    $pdo->exec("ALTER TABLE `users` DROP PRIMARY KEY, DROP COLUMN `id`;");
-    $pdo->exec("ALTER TABLE `users` ADD PRIMARY KEY (`telegram_id`);");
-    echo "   Primary key for `users` is now `telegram_id`." . PHP_EOL;
-    // Bots
-    $pdo->exec("ALTER TABLE `bots` DROP PRIMARY KEY, DROP COLUMN `id`;");
-    $pdo->exec("ALTER TABLE `bots` MODIFY `telegram_bot_id` BIGINT NOT NULL;");
-    $pdo->exec("ALTER TABLE `bots` ADD PRIMARY KEY (`telegram_bot_id`);");
-    echo "   Primary key for `bots` is now `telegram_bot_id`." . PHP_EOL;
-
-    // 6. Re-create Foreign Keys
-    echo "6. Re-creating foreign keys..." . PHP_EOL;
-    foreach ($constraints_to_rebuild as $table => $constraints) {
-        foreach ($constraints as $constraint) {
-            $pdo->exec(
-                "ALTER TABLE `$table` ADD CONSTRAINT `{$constraint['name']}` " .
-                "FOREIGN KEY (`{$constraint['col']}`) REFERENCES `{$constraint['ref_table']}`(`{$constraint['ref_col']}`) ON DELETE CASCADE;"
-            );
-            echo "   Created FK `{$constraint['name']}` on `$table`." . PHP_EOL;
-        }
-    }
+    echo "Migration 035 has been intentionally disabled due to inconsistency with the final database schema." . PHP_EOL;
+    echo "No changes were made." . PHP_EOL;
 
     if ($is_managing_transaction) {
         $pdo->commit();
-        echo PHP_EOL . "Migration successful! This script committed the transaction." . PHP_EOL;
+        echo PHP_EOL . "Migration successful (no-op)! This script committed the transaction." . PHP_EOL;
     } else {
-        echo PHP_EOL . "Migration step successful! Transaction will be committed by the parent runner." . PHP_EOL;
+        echo PHP_EOL . "Migration step successful (no-op)! Transaction will be committed by the parent runner." . PHP_EOL;
     }
 
 } catch (Exception $e) {
@@ -170,6 +59,5 @@ try {
         $pdo->rollBack();
         echo PHP_EOL . "Transaction rolled back by this script." . PHP_EOL;
     }
-    // Lemparkan kembali error agar runner utama bisa menangkapnya
     throw $e;
 }

--- a/webhook.php
+++ b/webhook.php
@@ -28,7 +28,7 @@ try {
         app_log("Webhook Error: ID bot dari URL tidak valid atau tidak ada.", 'bot');
         exit;
     }
-    $telegram_bot_id = (int)$_GET['id'];
+    $bot_id = (int)$_GET['id'];
 
     // 2. Koneksi ke DB
     $pdo = get_db_connection();
@@ -41,17 +41,17 @@ try {
 
     // 3. Temukan bot di database
     $bot_repo = new BotRepository($pdo);
-    $bot = $bot_repo->findBotByTelegramId($telegram_bot_id);
+    $bot = $bot_repo->findBotByTelegramId($bot_id);
 
     if (!$bot) {
         http_response_code(404); // Not Found
-        app_log("Webhook Error: Bot dengan ID Telegram {$telegram_bot_id} tidak ditemukan.", 'bot');
+        app_log("Webhook Error: Bot dengan ID Telegram {$bot_id} tidak ditemukan.", 'bot');
         exit;
     }
 
     // 4. Definisikan konstanta global yang mungkin dibutuhkan (cth: untuk inline query)
     require_once __DIR__ . '/core/TelegramAPI.php';
-    $api_for_globals = new TelegramAPI($bot['token'], $pdo, $telegram_bot_id);
+    $api_for_globals = new TelegramAPI($bot['token'], $pdo, $bot_id);
     $bot_info = $api_for_globals->getMe();
     if ($bot_info['ok'] && !defined('BOT_USERNAME')) {
         define('BOT_USERNAME', $bot_info['result']['username'] ?? '');

--- a/xoradmin.php
+++ b/xoradmin.php
@@ -98,16 +98,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         $bot_result = $bot_info['result'];
                         $first_name = $bot_result['first_name'];
                         $username = $bot_result['username'] ?? null;
-                        $telegram_bot_id = $bot_result['id'];
+                        $bot_id = $bot_result['id'];
 
                         $stmt_check_id = $pdo->prepare("SELECT id FROM bots WHERE id = ?");
-                        $stmt_check_id->execute([$telegram_bot_id]);
+                        $stmt_check_id->execute([$bot_id]);
                         if ($stmt_check_id->fetch()) {
-                             throw new Exception("Bot dengan ID Telegram {$telegram_bot_id} ini sudah terdaftar.", 23000);
+                             throw new Exception("Bot dengan ID Telegram {$bot_id} ini sudah terdaftar.", 23000);
                         }
 
                         $stmt = $pdo->prepare("INSERT INTO bots (id, first_name, username, token) VALUES (?, ?, ?, ?)");
-                        $stmt->execute([$telegram_bot_id, $first_name, $username, $token]);
+                        $stmt->execute([$bot_id, $first_name, $username, $token]);
                         $bot_message = "Bot '{$first_name}' (@{$username}) berhasil ditambahkan!";
                     } else {
                         throw new Exception("Token tidak valid atau gagal menghubungi API Telegram. " . ($bot_info['description'] ?? ''));


### PR DESCRIPTION
Memperbaiki error fatal `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'telegram_bot_id'` dengan melakukan refactoring global.

- Mengganti semua penggunaan `telegram_bot_id` di query dan kode PHP menjadi `id` agar sesuai dengan skema database.
- Menyesuaikan nama variabel terkait untuk konsistensi.
- Menonaktifkan migrasi usang yang mereferensikan nama kolom yang salah.