### PR TITLE
Feat: Tambah fitur reset database dan perbaiki kolom ID bot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.5.0] - 2025-08-27
+
+### Fitur
+- **Reset Database dari File SQL**: Menambahkan fitur baru di halaman `admin/database.php` yang memungkinkan admin untuk me-reset database menggunakan file skema SQL yang dipilih.
+  - **Dropdown Pilihan File**: Mengganti tombol "Bersihkan Data" dengan dropdown yang berisi `updated_schema.sql` (disarankan) dan `setup.sql` (lama).
+  - **Logika Reset Penuh**: Aksi ini akan menghapus semua tabel yang ada dan menjalankan skrip dari file yang dipilih untuk membuat ulang seluruh skema database.
+
 ## [4.4.2] - 2025-08-27
 
 ### Diperbaiki


### PR DESCRIPTION
- Menambahkan dropdown di `admin/database.php` untuk memilih file skema (`updated_schema.sql` atau `setup.sql`) untuk melakukan reset database penuh.
- Mengimplementasikan logika backend untuk menangani proses reset ini.

Fix: Perbaiki penggunaan `telegram_bot_id` di seluruh basis kode.
- Mengganti semua referensi ke `telegram_bot_id` dengan `id` agar konsisten dengan skema database.
- Menyelesaikan masalah ini secara global di semua file yang terpengaruh.