### PR TITLE
Fix: Pesan di Riwayat Chat Tidak Muncul dan Perbaikan Kumulatif Lainnya

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.6.2] - 2025-08-27
+
+### Diperbaiki
+- **Pesan di Riwayat Chat Tidak Muncul**: Memperbaiki bug di halaman `admin/chat.php` di mana total jumlah pesan ditampilkan dengan benar, tetapi tabel riwayat pesan tetap kosong.
+  - **Penyebab**: Kueri SQL untuk mengambil data pesan menggunakan kondisi `JOIN` yang salah antara tabel `messages` dan `media_files`. Kueri tersebut mencoba mencocokkan `messages.telegram_message_id` dengan `media_files.message_id`, padahal seharusnya mencocokkan `messages.id` (primary key) dengan `media_files.message_id`.
+  - **Solusi**: Mengubah kondisi `JOIN` menjadi `ON m.id = mf.message_id` dan membuat daftar `SELECT` menjadi eksplisit untuk mencegah potensi masalah tumpang tindih nama kolom.
+
 ## [4.6.1] - 2025-08-27
 
 ### Diperbaiki

--- a/admin/chat.php
+++ b/admin/chat.php
@@ -59,9 +59,11 @@ $count_stmt->execute([$telegram_id, $bot_id]);
 $total_messages = $count_stmt->fetchColumn();
 $total_pages = ceil($total_messages / $limit);
 
-$sql = "SELECT m.*, mf.type as media_type
+$sql = "SELECT m.id, m.user_id, m.bot_id, m.telegram_message_id, m.chat_id, m.chat_type,
+               m.update_type, m.text, m.raw_data, m.direction, m.telegram_timestamp, m.created_at,
+               mf.type as media_type
         FROM messages m
-        LEFT JOIN media_files mf ON m.telegram_message_id = mf.message_id AND m.chat_id = mf.chat_id
+        LEFT JOIN media_files mf ON m.id = mf.message_id
         WHERE m.user_id = ? AND m.bot_id = ?
         ORDER BY m.created_at DESC
         LIMIT ? OFFSET ?";


### PR DESCRIPTION
Perbaikan ini mengatasi bug di `admin/chat.php` di mana tabel riwayat pesan kosong meskipun jumlah total pesan sudah benar.

- **Penyebab**: Kueri SQL untuk mengambil pesan menggunakan kondisi JOIN yang salah (`messages.telegram_message_id` ke `media_files.message_id`).
- **Solusi**: Mengubah kondisi JOIN menjadi `ON messages.id = media_files.message_id` dan membuat daftar kolom SELECT menjadi eksplisit.

Commit ini juga mencakup serangkaian perbaikan dan fitur kumulatif dari sesi kerja sebelumnya, termasuk:
- Refactoring global untuk konsistensi nama kolom (`telegram_id` -> `id`).
- Halaman baru untuk 'Channel Jualan' (`admin/sales_channels.php`).
- Fitur reset database di panel admin.
- Perbaikan berbagai error fatal di seluruh panel admin.
- Pembaruan `CHANGELOG.md` yang komprehensif.