### PR TITLE
Refactor: Gunakan ID Telegram untuk API Manajemen Channel

### DIFF
--- a/admin/api/get_channel_bots.php
+++ b/admin/api/get_channel_bots.php
@@ -22,16 +22,25 @@ if (!$pdo) {
 }
 
 // --- Input ---
-$channel_id = filter_input(INPUT_GET, 'channel_id', FILTER_VALIDATE_INT);
-if (!$channel_id) {
+$telegram_channel_id = filter_input(INPUT_GET, 'channel_id', FILTER_VALIDATE_INT);
+if (!$telegram_channel_id) {
     echo json_encode(['status' => 'error', 'message' => 'Input tidak valid: channel_id diperlukan.']);
     exit;
 }
 
 // --- Logika ---
 try {
+    require_once __DIR__ . '/../../core/database/PrivateChannelRepository.php';
+    $channelRepo = new PrivateChannelRepository($pdo);
+    $channel = $channelRepo->findByTelegramId($telegram_channel_id);
+
+    if (!$channel) {
+        throw new Exception("Channel tidak ditemukan.");
+    }
+
+    $internal_channel_id = $channel['id'];
     $pcBotRepo = new PrivateChannelBotRepository($pdo);
-    $bots = $pcBotRepo->getBotsForChannel($channel_id);
+    $bots = $pcBotRepo->getBotsForChannel($internal_channel_id);
 
     echo json_encode(['status' => 'success', 'bots' => $bots]);
 

--- a/admin/api/remove_bot_from_channel.php
+++ b/admin/api/remove_bot_from_channel.php
@@ -27,19 +27,28 @@ if (!$pdo) {
 }
 
 // --- Input ---
-$channel_id = filter_input(INPUT_POST, 'channel_id', FILTER_VALIDATE_INT);
+$telegram_channel_id = filter_input(INPUT_POST, 'channel_id', FILTER_VALIDATE_INT);
 $bot_id = filter_input(INPUT_POST, 'bot_id', FILTER_VALIDATE_INT);
 
-if (!$channel_id || !$bot_id) {
+if (!$telegram_channel_id || !$bot_id) {
     echo json_encode(['status' => 'error', 'message' => 'Input tidak valid: channel_id dan bot_id diperlukan.']);
     exit;
 }
 
 // --- Logika ---
 try {
+    require_once __DIR__ . '/../../core/database/PrivateChannelRepository.php';
+    $channelRepo = new PrivateChannelRepository($pdo);
+    $channel = $channelRepo->findByTelegramId($telegram_channel_id);
+
+    if (!$channel) {
+        throw new Exception("Channel tidak ditemukan.");
+    }
+
+    $internal_channel_id = $channel['id'];
     $pcBotRepo = new PrivateChannelBotRepository($pdo);
 
-    if ($pcBotRepo->removeBotFromChannel($channel_id, $bot_id)) {
+    if ($pcBotRepo->removeBotFromChannel($internal_channel_id, $bot_id)) {
         echo json_encode(['status' => 'success', 'message' => 'Bot berhasil dihapus dari channel.']);
     } else {
         throw new Exception("Gagal menghapus bot dari channel di database.");

--- a/admin/channels.php
+++ b/admin/channels.php
@@ -37,13 +37,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
     }
 
     if ($action === 'delete_channel') {
-        $id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT);
-        if ($id) {
-            if ($channelRepo->deleteChannel($id)) {
+        $telegram_channel_id = filter_input(INPUT_POST, 'channel_id', FILTER_VALIDATE_INT);
+        if ($telegram_channel_id) {
+            if ($channelRepo->deleteByTelegramId($telegram_channel_id)) {
                 $_SESSION['message'] = "Channel berhasil dihapus.";
             } else {
                 $_SESSION['message'] = "Gagal menghapus channel.";
             }
+        } else {
+            $_SESSION['message'] = "ID Channel tidak valid untuk penghapusan.";
         }
         header("Location: channels.php");
         exit;
@@ -173,7 +175,7 @@ require_once __DIR__ . '/../partials/header.php';
                     <td><?php echo htmlspecialchars($channel['bot_usernames'] ?? 'N/A'); ?></td>
                     <td>
                         <button class="btn btn-primary manage-bots-btn"
-                                data-channel-id="<?php echo $channel['id']; ?>"
+                                data-channel-id="<?php echo $channel['channel_id']; ?>"
                                 data-channel-name="<?php echo htmlspecialchars($channel['name']); ?>">
                             Kelola Bot
                         </button>
@@ -218,9 +220,9 @@ require_once __DIR__ . '/../partials/header.php';
 
         <hr>
 
-        <form action="channels.php" method="post" onsubmit="return confirm('Yakin ingin menghapus channel ini beserta semua hubungan bot-nya?');">
+        <form id="delete-channel-form" action="channels.php" method="post" onsubmit="return confirm('Yakin ingin menghapus channel ini beserta semua hubungan bot-nya?');">
             <input type="hidden" name="action" value="delete_channel">
-            <input type="hidden" id="delete-channel-id" name="id">
+            <input type="hidden" id="delete-channel-id-input" name="channel_id">
             <button type="submit" class="btn btn-danger">Hapus Channel Ini</button>
         </form>
     </div>
@@ -313,7 +315,7 @@ document.addEventListener('DOMContentLoaded', function () {
             const channelName = btn.dataset.channelName;
             modal.querySelector('#modal-title').innerText = 'Kelola Bot untuk Channel: ' + channelName;
             modalChannelIdInput.value = channelId;
-            modal.querySelector('#delete-channel-id').value = channelId;
+            modal.querySelector('#delete-channel-id-input').value = channelId;
             modalNotifications.innerHTML = '';
             modal.style.display = 'block';
             loadConnectedBots(channelId);

--- a/core/database/PrivateChannelRepository.php
+++ b/core/database/PrivateChannelRepository.php
@@ -53,6 +53,18 @@ class PrivateChannelRepository
     }
 
     /**
+     * Menghapus channel dari database berdasarkan ID Telegram-nya.
+     *
+     * @param int $telegram_id ID unik dari channel Telegram.
+     * @return bool True jika berhasil, false jika gagal.
+     */
+    public function deleteByTelegramId(int $telegram_id): bool
+    {
+        $stmt = $this->pdo->prepare("DELETE FROM private_channels WHERE channel_id = ?");
+        return $stmt->execute([$telegram_id]);
+    }
+
+    /**
      * Mendapatkan semua channel pribadi dari database, beserta bot yang terhubung.
      *
      * @return array Daftar semua channel dengan informasi bot terkait.
@@ -91,6 +103,19 @@ class PrivateChannelRepository
     {
         $stmt = $this->pdo->prepare("SELECT * FROM private_channels WHERE id = ?");
         $stmt->execute([$id]);
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Mendapatkan satu channel berdasarkan ID Telegram-nya.
+     *
+     * @param int $telegram_id
+     * @return array|false
+     */
+    public function findByTelegramId(int $telegram_id)
+    {
+        $stmt = $this->pdo->prepare("SELECT * FROM private_channels WHERE channel_id = ?");
+        $stmt->execute([$telegram_id]);
         return $stmt->fetch(PDO::FETCH_ASSOC);
     }
 }


### PR DESCRIPTION
Melakukan refactoring pada fitur manajemen bot channel untuk menggunakan ID channel Telegram publik, bukan ID database internal, pada semua interaksi UI dan panggilan API.

Perubahan ini meliputi:
- Memperbarui `admin/channels.php` untuk menggunakan `channel_id` Telegram di atribut data HTML dan formulir.
- Menyesuaikan semua endpoint API terkait (`get_channel_bots`, `add_bot_to_channel`, `remove_bot_from_channel`, `verify_channel_bot`) untuk menerima ID Telegram dan menerjemahkannya ke ID internal di backend.
- Menambahkan metode `findByTelegramId` dan `deleteByTelegramId` ke `PrivateChannelRepository` untuk mendukung alur kerja baru ini.
- Memperbarui logika penghapusan channel untuk bekerja dengan ID Telegram.