### PR TITLE
Perbaikan: Atasi Error Sesi tidak Valid pada API Manajemen Channel

### DIFF
--- a/admin/api/add_bot_to_channel.php
+++ b/admin/api/add_bot_to_channel.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/../../core/database.php';
 require_once __DIR__ . '/../../core/database/PrivateChannelBotRepository.php';
 
 // --- Keamanan & Inisialisasi ---
-if (!isset($_SESSION['is_authenticated']) || !$_SESSION['is_authenticated']) {
+if (!isset($_SESSION['is_admin']) || $_SESSION['is_admin'] !== true) {
     echo json_encode(['status' => 'error', 'message' => 'Akses ditolak. Sesi tidak valid.']);
     exit;
 }

--- a/admin/api/get_channel_bots.php
+++ b/admin/api/get_channel_bots.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/../../core/database.php';
 require_once __DIR__ . '/../../core/database/PrivateChannelBotRepository.php';
 
 // --- Keamanan & Inisialisasi ---
-if (!isset($_SESSION['is_authenticated']) || !$_SESSION['is_authenticated']) {
+if (!isset($_SESSION['is_admin']) || $_SESSION['is_admin'] !== true) {
     echo json_encode(['status' => 'error', 'message' => 'Akses ditolak. Sesi tidak valid.']);
     exit;
 }

--- a/admin/api/remove_bot_from_channel.php
+++ b/admin/api/remove_bot_from_channel.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/../../core/database.php';
 require_once __DIR__ . '/../../core/database/PrivateChannelBotRepository.php';
 
 // --- Keamanan & Inisialisasi ---
-if (!isset($_SESSION['is_authenticated']) || !$_SESSION['is_authenticated']) {
+if (!isset($_SESSION['is_admin']) || $_SESSION['is_admin'] !== true) {
     echo json_encode(['status' => 'error', 'message' => 'Akses ditolak. Sesi tidak valid.']);
     exit;
 }

--- a/admin/api/verify_channel_bot.php
+++ b/admin/api/verify_channel_bot.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/../../core/database/PrivateChannelRepository.php';
 require_once __DIR__ . '/../../core/database/PrivateChannelBotRepository.php';
 
 // --- Keamanan & Inisialisasi ---
-if (!isset($_SESSION['is_authenticated']) || !$_SESSION['is_authenticated']) {
+if (!isset($_SESSION['is_admin']) || $_SESSION['is_admin'] !== true) {
     echo json_encode(['status' => 'error', 'message' => 'Akses ditolak. Sesi tidak valid.']);
     exit;
 }


### PR DESCRIPTION
Memperbaiki bug di mana semua panggilan API dari modal manajemen channel gagal dengan pesan "Akses ditolak. Sesi tidak valid."

Penyebabnya adalah file-file API baru memeriksa kunci sesi `$_SESSION['is_authenticated']`, padahal sistem autentikasi admin yang ada menggunakan `$_SESSION['is_admin']`.

Perubahan:
- Mengubah pengecekan sesi di `get_channel_bots.php`, `add_bot_to_channel.php`, `remove_bot_from_channel.php`, dan `verify_channel_bot.php` agar menggunakan `$_SESSION['is_admin'] === true`.