### PR TITLE
Perbaiki Penanganan Perintah di Grup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.0.8] - 2025-08-29
+
+### Diperbaiki
+- **Penanganan Perintah di Grup**: Memperbaiki bug di `MessageHandler` yang menyebabkan bot tidak merespons perintah yang dikirim di dalam grup jika perintah tersebut menyertakan nama bot (misalnya, `/start@nama_bot_saya`). Logika parsing sekarang dengan benar memisahkan perintah dari nama bot, memastikan perintah dikenali dan diproses dengan benar di semua jenis chat.
+
 ## [5.0.7] - 2025-08-29
 
 ### Peningkatan

--- a/core/handlers/MessageHandler.php
+++ b/core/handlers/MessageHandler.php
@@ -43,7 +43,10 @@ class MessageHandler implements HandlerInterface
         $text = $message['text'];
 
         $parts = explode(' ', $text);
-        $command = $parts[0];
+        $command_full = $parts[0];
+        // Menangani perintah yang mungkin menyertakan nama bot (misal: /start@nama_bot)
+        $command_parts = explode('@', $command_full);
+        $command = $command_parts[0];
 
         // Ini dapat direfaktor lebih lanjut menjadi kelas-kelas perintah
         switch ($command) {


### PR DESCRIPTION
Memperbaiki bug di MessageHandler yang menyebabkan bot tidak merespons perintah yang dikirim di dalam grup jika perintah tersebut menyertakan nama bot (misalnya, /start@nama_bot_saya).

Logika parsing sekarang dengan benar memisahkan perintah dari nama bot, memastikan perintah dikenali dan diproses dengan benar di semua jenis chat.

Sesuai dengan AGENTS.md, pengujian tidak dijalankan karena akan dilakukan secara manual.