### PR TITLE
Memperkuat keamanan pada proses login di XorAdminController dengan me…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [5.0.9] - 2025-08-29
+
+### Diperbaiki (Keamanan)
+
+- **Validasi Input Tambahan**: Memperkuat keamanan di `XorAdminController` dengan menambahkan pemeriksaan `is_string()` sebelum memanggil `hash_equals()`. Ini mencegah potensi peringatan (warning) dan memastikan hanya string yang dibandingkan, melindungi dari serangan manipulasi tipe data.
+
 ## [5.0.8] - 2025-08-29
 
 ### Diperbaiki

--- a/src/Controllers/Admin/XorAdminController.php
+++ b/src/Controllers/Admin/XorAdminController.php
@@ -113,7 +113,7 @@ class XorAdminController extends BaseController
 
     public function login()
     {
-        if (isset($_POST['password']) && !empty($this->correct_password) && hash_equals($this->correct_password, $_POST['password'])) {
+        if (isset($_POST['password']) && is_string($_POST['password']) && !empty($this->correct_password) && hash_equals($this->correct_password, $_POST['password'])) {
             $_SESSION['is_authenticated'] = true;
         } else {
             $_SESSION['xor_error'] = "Password salah!";


### PR DESCRIPTION
…nambahkan pemeriksaan is_string() untuk `$_POST['password']`.

Langkah ini mencegah potensi peringatan (warning) yang dapat terjadi jika input yang diberikan bukan string (misalnya, array yang dimanipulasi seperti `password[]=...`). Dengan memastikan tipe data yang benar sebelum perbandingan hash, validasi menjadi lebih kuat dan tahan terhadap serangan manipulasi tipe data.

CHANGELOG.md juga telah diperbarui untuk mencatat perbaikan ini.