### PR TITLE
Meningkatkan pengalaman pengguna di panel manajemen peran dengan memb…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## [5.0.9] - 2025-08-29
+## [5.1.0] - 2025-08-29
 
 ### Peningkatan
 
 - **Pesan Status yang Lebih Akurat**: Memperbaiki logika penambahan peran di `RoleController`. Sistem sekarang memberikan pesan yang jelas kepada pengguna jika peran berhasil ditambahkan, jika peran tersebut sudah ada, atau jika terjadi kesalahan, daripada hanya menampilkan pesan sukses umum.
 - **Perbaikan Bug Variabel**: Memperbaiki bug di `RoleController` di mana variabel `$roleRepo` dipanggil alih-alih properti kelas `$this->roleRepo`, yang akan menyebabkan error fatal.
+- **Pesan Status Hapus yang Lebih Akurat**: Mengikuti pembaruan sebelumnya, logika penghapusan peran di `RoleController` kini juga telah diperbaiki. Sistem sekarang memberikan pesan yang jelas kepada pengguna jika peran berhasil dihapus, jika peran tidak ditemukan (sehingga tidak ada yang dihapus), atau jika terjadi kesalahan database.
 
 ## [5.0.8] - 2025-08-29
 

--- a/core/database/RoleRepository.php
+++ b/core/database/RoleRepository.php
@@ -26,9 +26,15 @@ class RoleRepository
         }
     }
 
-    public function deleteRole(int $id): bool
+    public function deleteRole(int $id): int
     {
-        $stmt = $this->pdo->prepare("DELETE FROM roles WHERE id = ?");
-        return $stmt->execute([$id]);
+        try {
+            $stmt = $this->pdo->prepare("DELETE FROM roles WHERE id = ?");
+            $stmt->execute([$id]);
+            return $stmt->rowCount();
+        } catch (PDOException $e) {
+            error_log("Error deleting role: " . $e->getMessage());
+            return -1;
+        }
     }
 }

--- a/src/Controllers/Admin/RoleController.php
+++ b/src/Controllers/Admin/RoleController.php
@@ -65,10 +65,14 @@ class RoleController extends BaseController
             exit();
         }
 
-        if ($this->roleRepo->deleteRole($role_id)) {
+        $rowCount = $this->roleRepo->deleteRole($role_id);
+
+        if ($rowCount > 0) {
             $_SESSION['flash_message'] = "Peran berhasil dihapus.";
+        } elseif ($rowCount === 0) {
+            $_SESSION['flash_message'] = "Gagal menghapus: Peran tidak ditemukan.";
         } else {
-            $_SESSION['flash_message'] = "Gagal menghapus peran.";
+            $_SESSION['flash_message'] = "Gagal menghapus peran karena kesalahan database.";
         }
 
         header("Location: /admin/roles");


### PR DESCRIPTION
…erikan umpan balik yang lebih akurat saat menghapus peran.

Sebelumnya, sistem menampilkan pesan "berhasil dihapus" bahkan jika peran yang ditargetkan tidak ada. Perubahan ini memodifikasi alur kerja sebagai berikut:

1.  **`RoleRepository::deleteRole`**: Metode ini sekarang mengembalikan `rowCount()` (integer), bukan hanya `true`/`false`. Ini memberikan informasi detail apakah sebuah baris benar-benar dihapus (1), tidak ada baris yang ditemukan (0), atau terjadi error (-1).
2.  **`RoleController::destroy`**: Logika di controller sekarang menggunakan `rowCount` untuk menampilkan pesan yang sesuai:
    - "Peran berhasil dihapus." (jika `rowCount` > 0)
    - "Gagal menghapus: Peran tidak ditemukan." (jika `rowCount` === 0)
    - "Gagal menghapus peran karena kesalahan database." (jika `rowCount` < 0)