### PR TITLE
Perbaiki: Penanganan error saat menambahkan bot ke channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.1.1] - 2025-08-29
+
+### Diperbaiki
+- **Penanganan Error Verifikasi Bot**: Menambahkan pemeriksaan error setelah memanggil `addBotToChannel` di dalam `StorageChannelController`. Sebelumnya, jika penambahan bot ke channel gagal di database, sistem akan tetap melanjutkan ke proses verifikasi, yang kemungkinan besar juga akan gagal. Sekarang, sebuah `Exception` akan dilempar lebih awal, memberikan pesan error yang jelas dan mencegah kegagalan berantai.
+
 ## [5.1.0] - 2025-08-29
 
 ### Peningkatan

--- a/src/Controllers/Admin/StorageChannelController.php
+++ b/src/Controllers/Admin/StorageChannelController.php
@@ -213,7 +213,9 @@ class StorageChannelController extends BaseController {
             $status = $member_info['result']['status'];
             if (in_array($status, ['creator', 'administrator'])) {
                 if (!$this->pcBotRepo->isBotInChannel($channel['id'], $bot_id)) {
-                    $this->pcBotRepo->addBotToChannel($channel['id'], $bot_id);
+                    if (!$this->pcBotRepo->addBotToChannel($channel['id'], $bot_id)) {
+                        throw new Exception("Gagal menambahkan bot ke channel saat proses verifikasi.");
+                    }
                 }
                 if ($this->pcBotRepo->verifyBotInChannel($channel['id'], $bot_id)) {
                     return $this->jsonResponse(['status' => 'success', 'message' => "Verifikasi berhasil! Bot adalah '{$status}'."]);


### PR DESCRIPTION
Memperbaiki bug di mana sistem tidak menangani kegagalan saat menambahkan bot ke channel dalam proses verifikasi.

Sebelumnya, jika metode `addBotToChannel` mengembalikan `false`, kode akan tetap melanjutkan ke langkah verifikasi berikutnya, yang menyebabkan potensi kegagalan lebih lanjut dan pesan error yang tidak jelas.

Perubahan ini menambahkan pemeriksaan pada nilai kembalian dari `addBotToChannel`. Jika gagal, sebuah `Exception` akan dilempar dengan pesan yang jelas, menghentikan eksekusi lebih awal dan meningkatkan pelaporan error.