### PR TITLE
Perbaikan: Perbaiki aturan htaccess dan contoh password di INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,8 +53,9 @@ Aplikasi ini dikonfigurasi melalui file `config.php`.
 
     // --- (OPSIONAL) PASSWORD ADMIN XOR ---
     // Password untuk mengakses panel admin alternatif.
-    // Ganti dengan password yang kuat dan aman.
-    define('XOR_ADMIN_PASSWORD', 'PasswordSangatAman123!');
+    // Ganti dengan password yang kuat dan unik. Sangat disarankan menggunakan
+    // password generator untuk membuat password yang tidak mudah ditebak.
+    define('XOR_ADMIN_PASSWORD', 'ganti_dengan_password_yang_sangat_kuat');
 
     ?>
     ```
@@ -131,15 +132,15 @@ Jika Anda menggunakan server web Apache (yang paling umum di shared hosting), An
     <IfModule mod_rewrite.c>
         RewriteEngine On
 
-        # Jika aplikasi ada di subdirektori, uncomment dan sesuaikan baris di bawah ini
+        # Jika aplikasi Anda berada di subdirektori, uncomment dan sesuaikan baris di bawah ini
         # RewriteBase /subfolder/
 
         RewriteCond %{REQUEST_FILENAME} !-f
         RewriteCond %{REQUEST_FILENAME} !-d
-        RewriteRule ^(.*)$ public/index.php?/$1 [L]
+        RewriteRule . public/index.php [L,QSA]
     </IfModule>
     ```
-    **Catatan**: `RewriteRule` di atas akan membuat URL seperti `example.my.id/admin/bots` berfungsi.
+    **Catatan**: Aturan ini mengarahkan semua permintaan ke `public/index.php`, sementara flag `[QSA]` (Query String Append) memastikan parameter seperti `?page=2` tetap utuh.
 
 ### Untuk Nginx
 


### PR DESCRIPTION
Melakukan dua perbaikan penting pada panduan instalasi berdasarkan masukan pengguna:

1.  Memperbaiki aturan `RewriteRule` di dalam contoh `.htaccess`. Aturan yang lama (`?/$1 [L]`) berpotensi menimpa query string. Aturan baru (`. public/index.php [L,QSA]`) lebih aman dan memastikan parameter URL asli tetap diteruskan.
2.  Menghapus contoh password yang berisiko dari `config.php.example`. Sebagai gantinya, instruksi sekarang menyarankan pengguna untuk membuat password yang kuat dan unik, idealnya menggunakan password generator.