### PR TITLE
Perbaikan: Ganti metode router 'any' yang tidak ada

### DIFF
--- a/routes.php
+++ b/routes.php
@@ -106,7 +106,8 @@ $router->get('/admin/sales_channels', 'Admin/SalesChannelController@index');
 
 // Admin - API Tester
 $router->get('/admin/api_test', 'Admin/ApiTestController@index');
-$router->any('/api/admin/api_test', 'Admin/ApiTestController@handle');
+$router->get('/api/admin/api_test', 'Admin/ApiTestController@handle');
+$router->post('/api/admin/api_test', 'Admin/ApiTestController@handle');
 
 // Admin - Debug Feed
 $router->get('/admin/debug_feed', 'Admin/DebugFeedController@index');


### PR DESCRIPTION
Memperbaiki error fatal "Call to undefined method Router::any()" yang terjadi di `routes.php`.

Metode `any()` tidak ada di dalam kelas `Router`. Panggilan tersebut telah diganti dengan dua panggilan terpisah untuk `get()` dan `post()` yang mengarah ke controller yang sama. Ini menyelesaikan error dan memungkinkan rute API tester untuk menerima kedua jenis request tersebut.