### PR TITLE
Perbaikan: Tambah file .htaccess untuk mengatasi 403 Forbidden

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,10 @@
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+
+    # Jika aplikasi Anda berada di subdirektori, uncomment dan sesuaikan baris di bawah ini
+    # RewriteBase /subfolder/
+
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule . public/index.php [L,QSA]
+</IfModule>


### PR DESCRIPTION
Menambahkan file `.htaccess` yang hilang di direktori root aplikasi.

Ketiadaan file ini menyebabkan server tidak dapat mengarahkan permintaan ke `public/index.php`, yang mengakibatkan error 403 Forbidden karena tidak ada file indeks di root dan directory listing dinonaktifkan.

File `.htaccess` yang baru ini berisi aturan `RewriteRule` yang benar untuk merutekan semua permintaan yang bukan file atau direktori ke front controller, yang akan memperbaiki masalah akses dan memungkinkan aplikasi berfungsi sebagaimana mestinya.