### PR TITLE
Perbaikan: Atasi error fatal pada pemanggilan callAction di Router

### DIFF
--- a/core/Router.php
+++ b/core/Router.php
@@ -39,10 +39,9 @@ class Router {
                 try {
                     $params = array_filter($matches, 'is_string', ARRAY_FILTER_USE_KEY);
 
-                    return $this->callAction(
-                        ...explode('@', $controller),
-                        $params
-                    );
+                    $parts = explode('@', $controller);
+
+                    return $this->callAction($parts[0], $parts[1], $params);
                 } catch (Exception $e) {
                     error_log("Router Error: " . $e->getMessage());
                     http_response_code(500);


### PR DESCRIPTION
Memperbaiki error fatal "Cannot use positional argument after argument unpacking".

Kesalahan ini disebabkan oleh penggunaan operator `...` (spread) yang salah saat memanggil `callAction`. Perbaikan ini mengubah logika untuk mem-parsing controller dan action terlebih dahulu, lalu meneruskannya sebagai argumen terpisah, yang menyelesaikan masalah sintaks.