### PR TITLE
Perbaikan: Atasi error path di semua Member Controller

### DIFF
--- a/src/Controllers/Member/ChannelController.php
+++ b/src/Controllers/Member/ChannelController.php
@@ -1,11 +1,11 @@
 <?php
 
-require_once __DIR__ . '/../MemberBaseController.php';
+require_once __DIR__ . '/BaseController.php';
 require_once __DIR__ . '/../../../core/database/SellerSalesChannelRepository.php';
 require_once __DIR__ . '/../../../core/TelegramAPI.php';
 require_once __DIR__ . '/../../../core/helpers.php';
 
-class ChannelController extends MemberBaseController {
+class ChannelController extends BaseController {
 
     public function index() {
         $pdo = get_db_connection();

--- a/src/Controllers/Member/ContentController.php
+++ b/src/Controllers/Member/ContentController.php
@@ -1,9 +1,9 @@
 <?php
 
-require_once __DIR__ . '/../MemberBaseController.php';
+require_once __DIR__ . '/BaseController.php';
 require_once __DIR__ . '/../../../core/database/PackageRepository.php';
 
-class ContentController extends MemberBaseController {
+class ContentController extends BaseController {
 
     public function index() {
         $pdo = get_db_connection();

--- a/src/Controllers/Member/DashboardController.php
+++ b/src/Controllers/Member/DashboardController.php
@@ -1,9 +1,9 @@
 <?php
 
-require_once __DIR__ . '/../MemberBaseController.php';
+require_once __DIR__ . '/BaseController.php';
 require_once __DIR__ . '/../../../core/database/AnalyticsRepository.php';
 
-class DashboardController extends MemberBaseController {
+class DashboardController extends BaseController {
 
     public function index() {
         // The constructor of MemberBaseController already handles the session check.

--- a/src/Controllers/Member/TransactionController.php
+++ b/src/Controllers/Member/TransactionController.php
@@ -1,10 +1,10 @@
 <?php
 
-require_once __DIR__ . '/../MemberBaseController.php';
+require_once __DIR__ . '/BaseController.php';
 require_once __DIR__ . '/../../../core/database/SaleRepository.php';
 require_once __DIR__ . '/../../../core/database/PackageRepository.php';
 
-class TransactionController extends MemberBaseController {
+class TransactionController extends BaseController {
 
     public function purchased() {
         $pdo = get_db_connection();


### PR DESCRIPTION
Memperbaiki error fatal "Failed to open stream: No such file or directory" yang terjadi pada controller di dalam direktori `src/Controllers/Member`.

Penyebabnya adalah beberapa controller mencoba memuat file `MemberBaseController.php` yang sudah tidak ada dari path yang salah. Perbaikan ini mengubah semua referensi di `DashboardController`, `ChannelController`, `ContentController`, dan `TransactionController` untuk memuat dan mewarisi dari `BaseController.php` yang benar, yang berada di direktori yang sama.