### PR TITLE
Perbaikan: Atasi error SQL pada query getAllChannels

### DIFF
--- a/core/database/PrivateChannelRepository.php
+++ b/core/database/PrivateChannelRepository.php
@@ -86,7 +86,7 @@ class PrivateChannelRepository
             LEFT JOIN
                 bots b ON pcb.bot_id = b.id
             GROUP BY
-                pc.id, pc.channel_id, pc.name
+                pc.id, pc.channel_id, pc.name, pc.is_default
             ORDER BY
                 pc.id ASC
         ";


### PR DESCRIPTION
Memperbaiki error fatal 500 yang terjadi saat mengakses halaman "Channel Penyimpanan".

Penyebabnya adalah query SQL di `PrivateChannelRepository::getAllChannels()` yang tidak mematuhi mode `ONLY_FULL_GROUP_BY` di MySQL. Query tersebut menyeleksi kolom `is_default` tetapi tidak menyertakannya dalam klausa `GROUP BY`.

Perbaikan ini menambahkan `pc.is_default` ke dalam klausa `GROUP BY`, membuat query menjadi valid dan menyelesaikan error.