### PR TITLE
Fix: Add missing namespace to UserRepository

### DIFF
--- a/core/database/UserRepository.php
+++ b/core/database/UserRepository.php
@@ -1,12 +1,17 @@
 <?php
 
+namespace TGBot\Database;
+
+use PDO;
+use Exception;
+
 /**
  * Repositori untuk mengelola data pengguna (`users`, `rel_user_bot`).
  * Menangani pembuatan pengguna, pencarian, pengelolaan state, dan peran.
  */
 class UserRepository
 {
-    private $pdo;
+    private PDO $pdo;
     private $bot_id;
 
     /**


### PR DESCRIPTION
The class `TGBot\Database\UserRepository` was not being found because the file `core/database/UserRepository.php` was missing its namespace declaration.

This commit adds the `namespace TGBot\Database;` declaration to the file, ensuring the class is correctly mapped by the autoloader. It also adds the required `use` statements for `PDO` and `Exception` and adds a type hint for the PDO property for consistency.