### PR TITLE
Perbaikan: Fatal Error Call to undefined function get_initials()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [5.1.28] - 2025-09-01
+
+### Diperbaiki
+- **Fatal Error `Call to undefined function get_initials()`**: Memperbaiki error fatal yang terjadi di dasbor admin.
+  - **Penyebab**: Fungsi helper `get_initials()`, yang digunakan untuk menampilkan avatar di daftar percakapan, dipanggil di view tetapi belum pernah didefinisikan.
+  - **Solusi**: Menambahkan fungsi `get_initials()` baru ke dalam `core/helpers.php` untuk membuat dan mengembalikan inisial dari nama pengguna atau judul channel.
+
 ## [5.1.27] - 2025-09-01
 
 ### Diperbaiki

--- a/core/helpers.php
+++ b/core/helpers.php
@@ -195,3 +195,40 @@ function is_active_nav(string $path, string $current_path, bool $exact = false):
     // Check if the current path starts with the given path, and also handles the base case e.g. /admin for /admin/dashboard
     return strpos($current_path, $path) === 0 || ($path === 'admin/dashboard' && $current_path === 'admin');
 }
+
+/**
+ * Mendapatkan inisial dari sebuah nama.
+ *
+ * @param string|null $name Nama lengkap.
+ * @return string Inisial yang dihasilkan (1 atau 2 karakter).
+ */
+function get_initials(?string $name): string
+{
+    if (empty(trim($name ?? ''))) {
+        return '?';
+    }
+
+    $words = preg_split("/[\s,]+/", trim($name));
+    $initials = '';
+
+    if (count($words) > 0) {
+        $first_letter = mb_substr($words[0], 0, 1);
+        if (ctype_alpha($first_letter)) {
+            $initials .= $first_letter;
+        }
+    }
+
+    if (count($words) > 1) {
+        $last_letter = mb_substr($words[count($words) - 1], 0, 1);
+         if (ctype_alpha($last_letter)) {
+            $initials .= $last_letter;
+        }
+    }
+
+    if (empty($initials)) {
+        // Fallback for names with no standard alpha characters (e.g., "😊")
+        return mb_substr(trim($name), 0, 1);
+    }
+
+    return strtoupper($initials);
+}


### PR DESCRIPTION
Memperbaiki error fatal `Call to undefined function get_initials()` yang terjadi di dasbor admin.

Penyebab masalah ini adalah fungsi helper `get_initials()`, yang digunakan untuk menampilkan avatar di daftar percakapan, dipanggil di view tetapi belum pernah didefinisikan.

Solusinya adalah dengan menambahkan fungsi `get_initials()` baru ke dalam `core/helpers.php` untuk membuat dan mengembalikan inisial dari nama pengguna atau judul channel.

Juga, `CHANGELOG.md` telah diperbarui untuk mencatat perbaikan ini.