### PR TITLE
feat: Implement "Tarik Post" functionality

### DIFF
--- a/core/database/ChannelPostPackageRepository.php
+++ b/core/database/ChannelPostPackageRepository.php
@@ -75,4 +75,20 @@ class ChannelPostPackageRepository
 
         return $result ?: null;
     }
+
+    /**
+     * Find a channel post by package ID.
+     *
+     * @param int $package_id
+     * @return array|null
+     */
+    public function findByPackageId(int $package_id): ?array
+    {
+        $sql = "SELECT * FROM channel_post_packages WHERE package_id = ? ORDER BY id DESC LIMIT 1";
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute([$package_id]);
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $result ?: null;
+    }
 }

--- a/core/database/PostPackageRepository.php
+++ b/core/database/PostPackageRepository.php
@@ -389,4 +389,17 @@ class PostPackageRepository
         $stmt->execute([$package_id]);
         return $stmt->fetch(PDO::FETCH_ASSOC);
     }
+
+    /**
+     * Update the status of a package.
+     *
+     * @param int $package_id
+     * @param string $status
+     * @return bool
+     */
+    public function updateStatus(int $package_id, string $status): bool
+    {
+        $stmt = $this->pdo->prepare("UPDATE post_packages SET status = ? WHERE id = ?");
+        return $stmt->execute([$status, $package_id]);
+    }
 }


### PR DESCRIPTION
This commit adds the "Tarik Post" (retract post) functionality, completing the feature set for the new /rate and /tanya commands.

Key changes:

1.  **Callback Handler**:
    *   Added a `handleRetractPost` method to `CallbackQueryHandler.php`.
    *   The `handle` method in `CallbackQueryHandler.php` now delegates callbacks starting with `retract_post_` to the new method.

2.  **Repository Methods**:
    *   Added `updateStatus` to `PostPackageRepository.php` to allow changing the status of a post (e.g., to 'deleted').
    *   Added `findByPackageId` to `ChannelPostPackageRepository.php` to find the public channel message associated with a post.

3.  **Retraction Logic**:
    *   The `handleRetractPost` method now contains the full logic to:
        *   Verify that the user clicking the button is the owner of the post.
        *   Find the corresponding message in the public channel.
        *   Delete the message from the public channel using the Telegram API.
        *   Update the post's status to 'deleted' in the database.
        *   Edit the user's notification message to confirm the retraction.
    *   The logic is wrapped in a database transaction to ensure atomicity.