### PR TITLE
feat: Add check for pending posts

### DIFF
--- a/core/database/PostPackageRepository.php
+++ b/core/database/PostPackageRepository.php
@@ -402,4 +402,17 @@ class PostPackageRepository
         $stmt = $this->pdo->prepare("UPDATE post_packages SET status = ? WHERE id = ?");
         return $stmt->execute([$status, $package_id]);
     }
+
+    /**
+     * Check if a user has a pending post.
+     *
+     * @param int $user_id
+     * @return bool
+     */
+    public function hasPendingPost(int $user_id): bool
+    {
+        $stmt = $this->pdo->prepare("SELECT 1 FROM post_packages WHERE seller_user_id = ? AND status = 'pending' LIMIT 1");
+        $stmt->execute([$user_id]);
+        return $stmt->fetchColumn() !== false;
+    }
 }

--- a/core/handlers/MessageHandler.php
+++ b/core/handlers/MessageHandler.php
@@ -531,6 +531,12 @@ EOT;
     private function handleRateCommand(App $app, array $message): void
     {
         $user_repo = new UserRepository($app->pdo, $app->bot['id']);
+        $post_repo = new PostPackageRepository($app->pdo);
+
+        if ($post_repo->hasPendingPost($app->user['id'])) {
+            $app->telegram_api->sendMessage($app->chat_id, "Anda masih memiliki kiriman yang sedang dalam proses moderasi. Harap tunggu hingga selesai sebelum mengirim yang baru.");
+            return;
+        }
 
         if (!isset($message['reply_to_message'])) {
             $app->telegram_api->sendMessage($app->chat_id, "Untuk memberi rate, silakan reply media yang ingin Anda beri rate dengan perintah /rate.");
@@ -580,6 +586,12 @@ EOT;
     private function handleTanyaCommand(App $app, array $message): void
     {
         $user_repo = new UserRepository($app->pdo, $app->bot['id']);
+        $post_repo = new PostPackageRepository($app->pdo);
+
+        if ($post_repo->hasPendingPost($app->user['id'])) {
+            $app->telegram_api->sendMessage($app->chat_id, "Anda masih memiliki kiriman yang sedang dalam proses moderasi. Harap tunggu hingga selesai sebelum mengirim yang baru.");
+            return;
+        }
 
         if (!isset($message['reply_to_message'])) {
             $app->telegram_api->sendMessage($app->chat_id, "Untuk bertanya, silakan reply pesan yang ingin Anda tanyakan dengan perintah /tanya.");


### PR DESCRIPTION
This commit adds a final enhancement to the /rate and /tanya features by preventing users from submitting a new post while they have another one pending moderation.

Key changes:

1.  **Repository Method**:
    *   Added a `hasPendingPost` method to `PostPackageRepository.php` to efficiently check if a user has any posts with a 'pending' status.

2.  **Command Handlers**:
    *   The `handleRateCommand` and `handleTanyaCommand` methods in `MessageHandler.php` now call `hasPendingPost` before processing a new submission.
    *   If a pending post is found, the user is notified and the command is not processed further.

This change ensures the workflow aligns with the requirement that users can only have one post in the moderation queue at a time.