### PR TITLE
fix: Use shared authentication for schema checker

### DIFF
--- a/core/helpers.php
+++ b/core/helpers.php
@@ -232,3 +232,16 @@ function get_initials(?string $name): string
 
     return strtoupper($initials);
 }
+
+/**
+ * Checks if either the main admin or XOR admin is logged in.
+ *
+ * @return bool
+ */
+function is_any_admin_logged_in(): bool
+{
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+    return (isset($_SESSION['is_admin']) && $_SESSION['is_admin'] === true) || (isset($_SESSION['xor_is_authenticated']) && $_SESSION['xor_is_authenticated'] === true);
+}

--- a/src/Controllers/Admin/DatabaseController.php
+++ b/src/Controllers/Admin/DatabaseController.php
@@ -7,13 +7,23 @@ namespace TGBot\Controllers\Admin;
 use Exception;
 use PDO;
 use Throwable;
-use TGBot\Controllers\BaseController;
+use TGBot\Controllers\AppController;
 
-class DatabaseController extends BaseController
+class DatabaseController extends AppController
 {
     /**
      * Menampilkan halaman manajemen database.
      */
+    public function __construct()
+    {
+        if (!is_any_admin_logged_in()) {
+            http_response_code(403);
+            // In a real app, you might want a more sophisticated access denied view
+            // that perhaps suggests logging into one of the available panels.
+            die('Access Denied. You must be logged in as an admin or XOR admin.');
+        }
+    }
+
     public function index()
     {
         try {


### PR DESCRIPTION
This commit fixes an authentication issue where the database schema checker page was not accessible to a logged-in XOR admin.

Instead of duplicating the feature, this fix implements a shared authentication check that allows access to users logged into either the main admin panel or the XOR admin panel.

Key changes:

1.  **Shared Authentication Function**:
    *   A new helper function `is_any_admin_logged_in()` has been added to `core/helpers.php`. This function checks for the existence of either `$_SESSION['is_admin']` or `$_SESSION['xor_is_authenticated']`.

2.  **Controller Update**:
    *   `DatabaseController.php` now extends `AppController` instead of `BaseController` to bypass the strict main admin session check.
    *   A constructor has been added to `DatabaseController` that calls the new `is_any_admin_logged_in()` function, ensuring that any user with either admin session can access all methods in the controller (including the schema checker).

3.  **UI Link Update**:
    *   The link in the XOR Admin panel now correctly points to the main admin schema checker page (`/admin/database/check`), which will now work correctly due to the shared authentication logic.