### PR TITLE
fix: Define BASE_PATH in DatabaseController

### DIFF
--- a/src/Controllers/Admin/DatabaseController.php
+++ b/src/Controllers/Admin/DatabaseController.php
@@ -16,6 +16,10 @@ class DatabaseController extends AppController
      */
     public function __construct()
     {
+        if (!defined('BASE_PATH')) {
+            define('BASE_PATH', realpath(__DIR__ . '/../../../'));
+        }
+
         if (!is_any_admin_logged_in()) {
             http_response_code(403);
             // In a real app, you might want a more sophisticated access denied view


### PR DESCRIPTION
This commit fixes a fatal error (`Undefined constant "BASE_PATH"`) that occurred when accessing the database schema checker.

The error was caused by changing the parent class of `DatabaseController` from `BaseController` to `AppController`, which removed the context where `BASE_PATH` was defined.

This fix re-introduces the `BASE_PATH` definition in the constructor of `DatabaseController`, ensuring that the `checkSchema` method can correctly locate the `updated_schema.sql` file.