### PR TITLE
Fix: Memperbaiki parser skema database yang salah mendeteksi tabel.

### DIFF
--- a/src/Controllers/Admin/DatabaseController.php
+++ b/src/Controllers/Admin/DatabaseController.php
@@ -192,7 +192,9 @@ class DatabaseController extends AppController
     private function parseSchemaFromFile(string $sql_content): array
     {
         $schema = [];
-        preg_match_all('/CREATE TABLE(?: IF NOT EXISTS)?\s*`?(\w+)`?\s*\((.*?)\)\s*ENGINE=/s', $sql_content, $matches, PREG_SET_ORDER);
+        // This new regex is more robust as it doesn't rely on the ENGINE keyword
+        // and instead looks for the closing semicolon of the CREATE TABLE statement.
+        preg_match_all('/CREATE TABLE(?: IF NOT EXISTS)?\s*`?(\w+)`?\s*\((.*?)\)[^;]+;/s', $sql_content, $matches, PREG_SET_ORDER);
 
         foreach ($matches as $match) {
             $table_name = $match[1];


### PR DESCRIPTION
Memperbaiki bug kritis pada fitur pemeriksa skema di mana parser gagal membaca beberapa definisi `CREATE TABLE` dari file `updated_schema.sql`. Kegagalan ini menyebabkan alat secara keliru melaporkan tabel yang valid (seperti `bots`) sebagai "tabel tambahan" dan menyarankan untuk menghapusnya.

Perbaikan ini mengganti regex parser menjadi lebih andal, memastikan semua tabel dalam file skema dapat dibaca dengan benar.