### PR TITLE
Fix: Memastikan `updated_schema.sql` sinkron sepenuhnya

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - **Tujuan**: Menghilangkan inkonsistensi antara kode dan skema database, memperbaiki bug, dan meningkatkan keterbacaan serta pemeliharaan kode.
 
 ### Diperbaiki
+- **Sinkronisasi `updated_schema.sql`**: Memperbaiki kelalaian di mana definisi tabel `feature_channels` yang baru tidak ditambahkan ke file `updated_schema.sql`, membuat file tersebut tidak sinkron. File skema sekarang sepenuhnya up-to-date.
 - **Skema Database Tidak Lengkap**: Memperbaiki file `updated_schema.sql` yang tidak lengkap dengan menambahkan kolom-kolom yang hilang.
   - **Kolom yang Ditambahkan**:
     - `assigned_feature` ke tabel `bots`.

--- a/updated_schema.sql
+++ b/updated_schema.sql
@@ -123,6 +123,28 @@ CREATE TABLE `channel_post_packages`  (
 ) ENGINE = InnoDB AUTO_INCREMENT = 18 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci COMMENT = 'Menghubungkan postingan di channel dengan paket media yang sesuai.' ROW_FORMAT = DYNAMIC;
 
 -- ----------------------------
+-- Table structure for feature_channels
+-- ----------------------------
+DROP TABLE IF EXISTS `feature_channels`;
+CREATE TABLE `feature_channels` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Nama internal untuk konfigurasi channel ini.',
+  `feature_type` enum('sell','rate','tanya') COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Fitur yang terhubung dengan konfigurasi ini.',
+  `moderation_channel_id` bigint(20) DEFAULT NULL COMMENT 'ID Channel pribadi untuk backup/moderasi.',
+  `public_channel_id` bigint(20) DEFAULT NULL COMMENT 'ID Channel publik untuk menampilkan post.',
+  `discussion_group_id` bigint(20) DEFAULT NULL COMMENT 'ID Grup diskusi yang terhubung.',
+  `managing_bot_id` bigint(20) NOT NULL COMMENT 'ID Bot yang mengelola channel ini.',
+  `owner_user_id` bigint(20) DEFAULT NULL COMMENT 'ID User pemilik channel ini (jika bukan milik admin).',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `managing_bot_id` (`managing_bot_id`),
+  KEY `owner_user_id` (`owner_user_id`),
+  CONSTRAINT `fk_feature_channel_bot` FOREIGN KEY (`managing_bot_id`) REFERENCES `bots` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_feature_channel_owner` FOREIGN KEY (`owner_user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Menyimpan konfigurasi channel untuk setiap fitur.';
+
+-- ----------------------------
 -- Table structure for media_files
 -- ----------------------------
 DROP TABLE IF EXISTS `media_files`;


### PR DESCRIPTION
Menambahkan definisi tabel `feature_channels` yang hilang ke dalam file `updated_schema.sql`.

Kelalaian ini menyebabkan file skema utama menjadi tidak sinkron dengan status database terbaru setelah migrasi. Perbaikan ini memastikan bahwa `updated_schema.sql` sekarang secara akurat mewakili skema database yang lengkap dan benar, termasuk semua fitur baru dan refactoring.