### PR TITLE
Perbaiki validasi token login member yang tidak andal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [5.2.0] - 2025-09-03
 
+### Diperbaiki
+- **Login Member Gagal**: Memperbaiki masalah kritis yang menghalangi member untuk login.
+  - **Penyebab**: Logika validasi token di `Member/LoginController.php` menggunakan perbandingan waktu berbasis PHP yang rentan terhadap perbedaan zona waktu antara server web dan database. Selain itu, tidak ada pemeriksaan peran (role) untuk memastikan hanya pengguna dengan peran 'Member' yang bisa login.
+  - **Solusi**: Mengganti total logika validasi token dengan metode yang lebih andal dan aman, yang sudah digunakan di `Auth/LoginController`. Validasi sekarang dilakukan dalam satu kueri SQL tunggal yang efisien, yang memeriksa validitas token, masa berlaku (menggunakan `NOW() - INTERVAL 5 MINUTE` di level database), dan peran 'Member' secara bersamaan.
+
 ### Diubah (Refactoring)
 - **Konsistensi Nama Tabel `media_packages`**: Melakukan refactoring besar di seluruh basis kode untuk menyelaraskan penggunaan nama tabel paket konten. Semua referensi ke tabel `post_packages` yang lama telah diubah menjadi `media_packages` agar sesuai dengan skema database terbaru.
   - **Perubahan Utama**:


### PR DESCRIPTION
Memperbaiki masalah kritis yang menghalangi member untuk login menggunakan token.

Logika validasi token di `Member/LoginController.php` telah diganti total. Metode lama yang menggunakan pengecekan waktu di PHP dan tidak memeriksa peran pengguna telah digantikan dengan satu kueri SQL yang efisien.

Kueri baru ini, yang diadaptasi dari `Auth/LoginController` yang sudah berfungsi dengan baik, sekarang melakukan hal berikut dalam satu langkah di level database:
- Memverifikasi token.
- Memeriksa masa berlaku token (5 menit) menggunakan `NOW()`.
- Memastikan pengguna memiliki peran 'Member'.

Perubahan ini menyelesaikan bug, meningkatkan keamanan dengan menambahkan pemeriksaan peran, dan membuat logika lebih andal dengan menghindari potensi masalah zona waktu.