### PR TITLE
This commit fixes a 500 Internal Server Error in the API Tester feature.

### DIFF
--- a/src/Controllers/Admin/ApiTestController.php
+++ b/src/Controllers/Admin/ApiTestController.php
@@ -115,7 +115,7 @@ class ApiTestController extends BaseController
     private function getMethods(): void
     {
         try {
-            $reflection = new ReflectionClass('TelegramAPI');
+            $reflection = new ReflectionClass(TelegramAPI::class);
             $public_methods = $reflection->getMethods(ReflectionMethod::IS_PUBLIC);
 
             $excluded_methods = ['__construct', '__call', 'escapeMarkdown', 'getBotId', 'sendLongMessage'];
@@ -193,7 +193,7 @@ class ApiTestController extends BaseController
                 $clean_params['message_thread_id'] = (int)$clean_params['message_thread_id'];
             }
 
-            $reflection = new ReflectionMethod('TelegramAPI', $method);
+            $reflection = new ReflectionMethod(TelegramAPI::class, $method);
             $final_args = [];
             foreach ($reflection->getParameters() as $param) {
                 $paramName = $param->getName();


### PR DESCRIPTION
- **Problem:** A GET request to `/api/xoradmin/api_test?action=get_methods` was failing with a 500 error. The root cause was that the `ApiTestController` was using string literals (e.g., `'TelegramAPI'`) in the `ReflectionClass` and `ReflectionMethod` constructors. This caused PHP to look for the class in the wrong namespace, resulting in a "Class not found" fatal error.

- **Solution:**
  - Modified `ApiTestController.php` to use the `::class` magic constant (e.g., `TelegramAPI::class`) when creating reflection objects. This provides the fully qualified class name and ensures that the correct class is always found, regardless of the current namespace.
  - Corrected this issue in both the `getMethods()` and `runMethod()` functions within the controller to prevent future errors.

This fix resolves the 500 error and restores the functionality of the API Tester page.