### PR TITLE
This commit improves the webhook URL generation logic in `BotControll…

### DIFF
--- a/src/Controllers/Admin/BotController.php
+++ b/src/Controllers/Admin/BotController.php
@@ -430,8 +430,9 @@ class BotController extends BaseController
     {
         $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
         $domain = $_SERVER['HTTP_HOST'];
-        // Construct the path to webhook.php from the web root.
-        $webhook_path = rtrim(str_replace(['/xoradmin', '/api/bots'], '', dirname($_SERVER['PHP_SELF'])), '/') . '/webhook.php';
-        return $protocol . $domain . $webhook_path . '?id=' . $bot_id;
+        // Using dirname($_SERVER['SCRIPT_NAME']) is more reliable for finding the application's base path
+        // and avoids the brittle str_replace.
+        $base_path = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/\\');
+        return $protocol . $domain . $base_path . '/webhook.php?id=' . $bot_id;
     }
 }


### PR DESCRIPTION
…er.php` based on user feedback.

- **Problem:** The previous logic for constructing the webhook URL used `dirname($_SERVER['PHP_SELF'])` and `str_replace`, which was brittle and could fail in different server environments.

- **Solution:**
  - The `generateWebhookUrl` private method has been refactored to use `dirname($_SERVER['SCRIPT_NAME'])` to reliably determine the application's base path.
  - This approach is more robust, portable, and removes the need for the fragile `str_replace` call.

This change improves the maintainability and reliability of the webhook setup feature.