### PR TITLE
Perbaiki: Hapus Batasan Waktu dan Peran pada Token Login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Diperbaiki
 - **Login Token Tanpa Batas Waktu**: Menghapus validasi masa berlaku token (5 menit) pada alur login member. Token sekarang tidak akan kedaluwarsa, memperbaiki masalah login yang gagal karena token dianggap hangus.
 
+### Diubah
+- **Login Token Lebih Fleksibel**: Menghapus pengecekan peran (role) dari alur login. Sekarang, semua pengguna yang memiliki token valid dapat login, tidak terbatas hanya pada 'Member'.
+
 ## [5.2.0] - 2025-09-04
 
 ### Diperbaiki

--- a/src/Controllers/Member/LoginController.php
+++ b/src/Controllers/Member/LoginController.php
@@ -112,15 +112,12 @@ class LoginController extends AppController
 
             $pdo = \get_db_connection();
 
-            // Check if token is valid, not used, and belongs to a Member
+            // Check if token is valid and not used
             $stmt = $pdo->prepare(
-                "SELECT u.id, u.first_name
-                 FROM users u
-                 LEFT JOIN user_roles ur ON u.id = ur.user_id
-                 LEFT JOIN roles r ON ur.role_id = r.id
-                 WHERE u.login_token = ?
-                   AND u.token_used = 0
-                   AND (r.name = 'Member' OR r.name IS NULL)"
+                "SELECT id, first_name
+                 FROM users
+                 WHERE login_token = ?
+                   AND token_used = 0"
             );
             $stmt->execute([$token]);
             $user = $stmt->fetch(PDO::FETCH_ASSOC);


### PR DESCRIPTION
Menghapus validasi masa berlaku token (sebelumnya 5 menit) dan pengecekan peran (role) dari alur login member di `src/Controllers/Member/LoginController.php`.

Perubahan ini memperbaiki masalah di mana member tidak dapat login karena token yang mereka terima dari bot Telegram sudah dianggap kedaluwarsa atau karena peran mereka tidak sesuai. Dengan menghapus kedua pemeriksaan ini, semua pengguna dengan token yang valid dapat login dengan sukses tanpa batasan waktu atau peran.