### PR TITLE
Perbaiki: Satukan Alur Login & Hapus Batasan Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - **Login Token Tanpa Batas Waktu**: Menghapus validasi masa berlaku token (5 menit) pada alur login member. Token sekarang tidak akan kedaluwarsa, memperbaiki masalah login yang gagal karena token dianggap hangus.
 
 ### Diubah
-- **Login Token Lebih Fleksibel**: Menghapus pengecekan peran (role) dari alur login. Sekarang, semua pengguna yang memiliki token valid dapat login, tidak terbatas hanya pada 'Member'.
+- **Login Token Lebih Fleksibel**: Menghapus pengecekan peran (role) dari alur validasi token di halaman web. Sekarang, semua pengguna yang memiliki token valid dapat login, tidak terbatas hanya pada 'Member'.
+- **Alur Perintah /login Disatukan**: Menyatukan respon perintah `/login` di sisi bot. Semua pengguna, terlepas dari perannya, sekarang menerima satu jenis pesan dan tautan login yang konsisten.
 
 ## [5.2.0] - 2025-09-04
 

--- a/core/handlers/MessageHandler.php
+++ b/core/handlers/MessageHandler.php
@@ -608,17 +608,10 @@ class MessageHandler implements HandlerInterface
         $app->pdo->prepare("UPDATE users SET login_token = ?, token_created_at = NOW(), token_used = 0 WHERE id = ?")
              ->execute([$login_token, $app->user['id']]);
 
-        if ($app->user['role'] === 'Admin') {
-            $login_link = rtrim(BASE_URL, '/') . '/login?token=' . $login_token;
-            $response = "Anda adalah seorang Admin. Silakan pilih panel yang ingin Anda masuki melalui tautan di bawah ini.";
-            $keyboard = ['inline_keyboard' => [[['text' => 'Pilih Panel Login', 'url' => $login_link]]]];
-            $app->telegram_api->sendMessage($app->chat_id, $response, null, json_encode($keyboard));
-        } else {
-            $login_link = rtrim(BASE_URL, '/') . '/member/token-login?token=' . $login_token;
-            $response = "Klik tombol di bawah ini untuk masuk ke Panel Member Anda. Tombol ini hanya dapat digunakan satu kali.";
-            $keyboard = ['inline_keyboard' => [[['text' => 'Login ke Panel Member', 'url' => $login_link]]]];
-            $app->telegram_api->sendMessage($app->chat_id, $response, null, json_encode($keyboard));
-        }
+        $login_link = rtrim(BASE_URL, '/') . '/member/token-login?token=' . $login_token;
+        $response = "Klik tombol di bawah ini untuk masuk ke Panel Anda. Tombol ini hanya dapat digunakan satu kali.";
+        $keyboard = ['inline_keyboard' => [[['text' => 'Login ke Panel', 'url' => $login_link]]]];
+        $app->telegram_api->sendMessage($app->chat_id, $response, null, json_encode($keyboard));
     }
 
     /**


### PR DESCRIPTION
Perbaikan ini mengatasi beberapa masalah terkait alur login member menggunakan token dari bot Telegram, berdasarkan serangkaian permintaan pengguna.

Perubahan yang dilakukan:
1.  **Hapus Batas Waktu Token**: Validasi masa berlaku token (sebelumnya 5 menit) dihapus dari `LoginController.php`. Token sekarang tidak akan kedaluwarsa.
2.  **Hapus Pengecekan Peran di Web**: Pengecekan peran 'Member' dihapus dari query validasi token di `LoginController.php`, memungkinkan semua pengguna dengan token valid untuk login.
3.  **Satukan Respon Perintah /login**: Logika di `MessageHandler.php` disederhanakan. Pengecekan peran `Admin` dihapus, sehingga semua pengguna menerima pesan dan tautan login yang sama dan konsisten dari bot.

Secara keseluruhan, perubahan ini menciptakan satu alur login yang tunggal, fleksibel, dan andal untuk semua pengguna, sesuai dengan arahan.