### PR TITLE
feat: Implement automatic seller registration and update ID generation

### DIFF
--- a/core/helpers.php
+++ b/core/helpers.php
@@ -75,12 +75,22 @@ function generate_random_string(int $length, string $characters): string {
 }
 
 /**
- * Menghasilkan ID penjual unik 4 karakter.
+ * Menghasilkan ID penjual unik yang dijamin unik di dalam database.
  *
- * @return string ID penjual 4 karakter.
+ * @param PDO $pdo Objek koneksi PDO untuk memeriksa keunikan.
+ * @return string ID penjual 5 karakter yang unik.
  */
-function generate_seller_id(): string {
-    return generate_random_string(4, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+function generate_seller_id(PDO $pdo): string
+{
+    $stmt = $pdo->prepare("SELECT 1 FROM users WHERE public_seller_id = ?");
+
+    do {
+        $sellerId = generate_random_string(5, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+        $stmt->execute([$sellerId]);
+        $exists = $stmt->fetchColumn();
+    } while ($exists);
+
+    return $sellerId;
 }
 
 /**

--- a/src/Controllers/Member/ContentController.php
+++ b/src/Controllers/Member/ContentController.php
@@ -313,8 +313,17 @@ class ContentController extends MemberBaseController
 
             $user = $userRepo->findUserByTelegramId($user_id);
             if (empty($user['public_seller_id'])) {
-                $_SESSION['flash_error'] = "Pendaftaran channel hanya untuk penjual terdaftar. Silakan daftar sebagai penjual melalui bot.";
-                \redirect('/member/channels');
+                // User is not a seller yet, let's register them automatically.
+                $new_seller_id = $userRepo->setPublicId($user_id);
+                $_SESSION['flash_message'] = "Selamat! Akun Anda telah terdaftar sebagai penjual dengan ID: " . $new_seller_id;
+
+                // Reload user data to get the new seller ID
+                $user = $userRepo->findUserByTelegramId($user_id);
+                if (empty($user['public_seller_id'])) {
+                    // This should not happen, but as a safeguard:
+                    $_SESSION['flash_error'] = "Gagal membuat ID penjual secara otomatis. Silakan coba lagi.";
+                    \redirect('/member/channels');
+                }
             }
 
             // Find the selected bot and verify it's a 'sell' bot


### PR DESCRIPTION
- Automatically registers a member as a seller if they are not one already when they try to register a sales channel.
- Increases the length of the seller ID from 4 to 5 characters.
- Adds a database check to ensure that all newly generated seller IDs are unique.
- Refactors the seller ID generation logic to be more robust.