### PR TITLE
fix: Final fixes for member channel management feature

### DIFF
--- a/src/Controllers/Member/ContentController.php
+++ b/src/Controllers/Member/ContentController.php
@@ -333,7 +333,7 @@ class ContentController extends MemberBaseController
                 \redirect('/member/channels');
             }
 
-            $managing_bot_api = new \TGBot\TelegramAPI($managing_bot['token']);
+            $managing_bot_api = new \TGBot\TelegramAPI($managing_bot['token'], $pdo, $managing_bot['id']);
 
             $bot_member_channel = $managing_bot_api->getChatMember($channel_id, $managing_bot_id);
             if (!$bot_member_channel || !$bot_member_channel['ok'] || !in_array($bot_member_channel['result']['status'], ['administrator', 'creator'])) {


### PR DESCRIPTION
This commit resolves a fatal error caused by the TelegramAPI class being instantiated without the required PDO object, which led to an uninitialized property error.

It also includes all previous enhancements:
- Automatic seller registration for new members.
- 5-character unique seller IDs.
- A new member-facing page to manage sales channels.
- Fixes to the member login flow.