### PR TITLE
Fix: Automate approval for /sell feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.2.5] - 2025-09-04
+
+### Diperbaiki
+- **Moderasi Otomatis untuk Fitur /sell**: Memperbaiki alur kerja fitur `/sell` yang sebelumnya secara keliru mengirimkan semua item untuk moderasi manual. Sekarang, item yang dijual melalui `/sell` akan secara otomatis ditandai sebagai `available` dan langsung dapat dibeli, sesuai dengan alur kerja yang diinginkan. Alur moderasi manual kini hanya berlaku untuk fitur `/rate` dan `/tanya`.
+
 ## [5.2.4] - 2025-09-04
 
 ### Fitur

--- a/core/database/MediaPackageRepository.php
+++ b/core/database/MediaPackageRepository.php
@@ -348,11 +348,14 @@ class MediaPackageRepository
             // 3. Buat ID publik
             $public_id = $seller_info['public_seller_id'] . '_' . str_pad($new_sequence, 4, '0', STR_PAD_LEFT);
 
-            // 4. Masukkan paket baru
+            // 4. Tentukan status awal berdasarkan jenis post
+            $initial_status = ($post_type === 'sell') ? 'available' : 'pending';
+
+            // 5. Masukkan paket baru
             $stmt_package = $this->pdo->prepare(
-                "INSERT INTO media_packages (seller_user_id, bot_id, description, thumbnail_media_id, status, public_id, post_type, category)\n                 VALUES (?, ?, ?, ?, 'pending', ?, ?, ?)"
+                "INSERT INTO media_packages (seller_user_id, bot_id, description, thumbnail_media_id, status, public_id, post_type, category)\n                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
             );
-            $stmt_package->execute([$seller_user_id, $bot_id, $description, $thumbnail_media_id, $public_id, $post_type, $category]);
+            $stmt_package->execute([$seller_user_id, $bot_id, $description, $thumbnail_media_id, $initial_status, $public_id, $post_type, $category]);
             $package_id = $this->pdo->lastInsertId();
 
             return (int)$package_id;


### PR DESCRIPTION
This change modifies the package creation logic to bypass manual moderation for items created via the `/sell` command.

Previously, all new packages were created with a 'pending' status, requiring admin approval. This change introduces a condition so that packages with the 'sell' post_type are now created with an 'available' status, making them immediately ready for purchase.

The manual moderation flow is preserved for other features like `/rate` and `/tanya`, as requested.