### PR TITLE
Feat: Add multi-channel support and fix sell moderation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [5.2.6] - 2025-09-04
+
+### Fitur
+- **Dukungan Multi-Channel untuk Penjual**: Member sekarang dapat mendaftarkan dan mengelola beberapa channel penjualan secara bersamaan.
+  - Tampilan panel member di `/member/channels` telah diubah untuk menampilkan daftar semua channel yang terdaftar.
+  - Member dapat menambahkan channel baru kapan saja, dan menghapus channel yang sudah ada.
+  - Fitur "Post ke Channel" sekarang akan menampilkan pilihan channel jika member memiliki lebih dari satu, memberikan kontrol penuh kepada penjual.
+
 ## [5.2.5] - 2025-09-04
 
 ### Diperbaiki

--- a/core/database/FeatureChannelRepository.php
+++ b/core/database/FeatureChannelRepository.php
@@ -85,12 +85,12 @@ class FeatureChannelRepository
     }
 
     /**
-     * Find a feature channel configuration by owner and feature type.
+     * Find all feature channel configurations by owner and feature type.
      */
-    public function findByOwnerAndFeature(int $owner_user_id, string $feature_type)
+    public function findAllByOwnerAndFeature(int $owner_user_id, string $feature_type): array
     {
-        $stmt = $this->pdo->prepare("SELECT * FROM feature_channels WHERE owner_user_id = ? AND feature_type = ? LIMIT 1");
+        $stmt = $this->pdo->prepare("SELECT * FROM feature_channels WHERE owner_user_id = ? AND feature_type = ?");
         $stmt->execute([$owner_user_id, $feature_type]);
-        return $stmt->fetch(PDO::FETCH_ASSOC);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 }

--- a/routes.php
+++ b/routes.php
@@ -101,6 +101,7 @@ $router->post('member/login', 'Member/LoginController@processFormLogin');
 $router->get('member/dashboard', 'Member/DashboardController@index');
 $router->get('member/channels', 'Member/ContentController@channels');
 $router->post('member/channels/register', 'Member/ContentController@registerChannel');
+$router->post('member/channels/delete', 'Member/ContentController@deleteChannel');
 $router->get('member/my_content', 'Member/ContentController@index');
 $router->get('member/content/edit', 'Member/ContentController@edit');
 $router->post('member/content/update', 'Member/ContentController@update');

--- a/src/Views/member/content/channels.php
+++ b/src/Views/member/content/channels.php
@@ -1,48 +1,53 @@
 <div class="container-fluid">
     <div class="row">
+        <!-- Channel List -->
         <div class="col-12">
             <div class="card">
                 <div class="card-header">
-                    <h3 class="card-title">Channel Jualan Terdaftar</h3>
+                    <h3 class="card-title">Daftar Channel Jualan</h3>
                 </div>
                 <div class="card-body">
-                    <?php if ($data['channel']) : ?>
-                        <p>Berikut adalah detail channel jualan yang terhubung dengan akun Anda.</p>
-                        <table class="table table-bordered">
-                            <tbody>
+                    <?php if (!empty($data['channels'])) : ?>
+                        <table class="table table-bordered table-striped">
+                            <thead>
                                 <tr>
-                                    <th style="width: 200px;">Nama Channel</th>
-                                    <td><?= htmlspecialchars($data['channel']['name']) ?></td>
-                                </tr>
-                                <tr>
+                                    <th>Nama Channel</th>
                                     <th>ID Channel Publik</th>
-                                    <td><code><?= htmlspecialchars($data['channel']['public_channel_id']) ?></code></td>
-                                </tr>
-                                <tr>
                                     <th>ID Grup Diskusi</th>
-                                    <td><code><?= htmlspecialchars($data['channel']['discussion_group_id']) ?></code></td>
-                                </tr>
-                                <tr>
                                     <th>Bot Pengelola</th>
-                                    <td>
-                                        <?php
-                                        $managing_bot_username = 'Tidak diketahui';
-                                        foreach ($data['sell_bots'] as $bot) {
-                                            if ($bot['id'] == $data['channel']['managing_bot_id']) {
-                                                $managing_bot_username = '@' . $bot['username'];
-                                                break;
-                                            }
-                                        }
-                                        echo htmlspecialchars($managing_bot_username);
-                                        ?>
-                                        (ID: <code><?= htmlspecialchars($data['channel']['managing_bot_id']) ?></code>)
-                                    </td>
+                                    <th style="width: 100px;">Aksi</th>
                                 </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($data['channels'] as $channel) : ?>
+                                    <tr>
+                                        <td><?= htmlspecialchars($channel['name']) ?></td>
+                                        <td><code><?= htmlspecialchars($channel['public_channel_id']) ?></code></td>
+                                        <td><code><?= htmlspecialchars($channel['discussion_group_id']) ?></code></td>
+                                        <td>
+                                            <?php
+                                            $managing_bot_username = 'Tidak diketahui';
+                                            foreach ($data['sell_bots'] as $bot) {
+                                                if ($bot['id'] == $channel['managing_bot_id']) {
+                                                    $managing_bot_username = '@' . $bot['username'];
+                                                    break;
+                                                }
+                                            }
+                                            echo htmlspecialchars($managing_bot_username);
+                                            ?>
+                                        </td>
+                                        <td>
+                                            <form action="/member/channels/delete" method="POST" onsubmit="return confirm('Apakah Anda yakin ingin menghapus channel ini?');">
+                                                <input type="hidden" name="channel_id" value="<?= $channel['id'] ?>">
+                                                <button type="submit" class="btn btn-danger btn-sm">
+                                                    <i class="fas fa-trash"></i> Hapus
+                                                </button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
                             </tbody>
                         </table>
-                        <button class="btn btn-primary mt-3" type="button" data-toggle="collapse" data-target="#channelForm" aria-expanded="false" aria-controls="channelForm">
-                            <i class="fas fa-edit"></i> Ubah Konfigurasi
-                        </button>
                     <?php else : ?>
                         <div class="alert alert-info">
                             <h5><i class="icon fas fa-info"></i> Belum Ada Channel Terdaftar</h5>
@@ -51,52 +56,53 @@
                     <?php endif; ?>
                 </div>
             </div>
+        </div>
 
-            <div class="collapse <?= !$data['channel'] ? 'show' : '' ?>" id="channelForm">
-                <div class="card card-primary">
-                    <div class="card-header">
-                        <h3 class="card-title"><?= $data['channel'] ? 'Perbarui' : 'Daftarkan' ?> Channel Jualan</h3>
-                    </div>
-                    <form action="/member/channels/register" method="POST">
-                    <div class="card-body">
-                        <?php if (isset($_SESSION['flash_error'])) : ?>
-                            <div class="alert alert-danger"><?= htmlspecialchars($_SESSION['flash_error']) ?></div>
-                            <?php unset($_SESSION['flash_error']); ?>
-                        <?php endif; ?>
-                        <?php if (isset($_SESSION['flash_message'])) : ?>
-                            <div class="alert alert-success"><?= htmlspecialchars($_SESSION['flash_message']) ?></div>
-                            <?php unset($_SESSION['flash_message']); ?>
-                        <?php endif; ?>
-
-                        <div class="form-group">
-                            <label for="channel_id">ID Channel Publik</label>
-                            <input type="text" class="form-control" id="channel_id" name="channel_id" value="<?= htmlspecialchars($data['channel']['public_channel_id'] ?? '') ?>" placeholder="-1001234567890" required>
-                        </div>
-                        <div class="form-group">
-                            <label for="group_id">ID Grup Diskusi</label>
-                            <input type="text" class="form-control" id="group_id" name="group_id" value="<?= htmlspecialchars($data['channel']['discussion_group_id'] ?? '') ?>" placeholder="-1009876543210" required>
-                        </div>
-                        <div class="form-group">
-                            <label for="managing_bot_id">Pilih Bot Pengelola</label>
-                            <select class="form-control" id="managing_bot_id" name="managing_bot_id" required>
-                                <option value="">-- Pilih Bot --</option>
-                                <?php foreach ($data['sell_bots'] as $bot) : ?>
-                                    <option value="<?= $bot['id'] ?>" <?= isset($data['channel']['managing_bot_id']) && $data['channel']['managing_bot_id'] == $bot['id'] ? 'selected' : '' ?>>
-                                        @<?= htmlspecialchars($bot['username']) ?>
-                                    </option>
-                                <?php endforeach; ?>
-                            </select>
-                            <small class="form-text text-muted">Pastikan bot yang Anda pilih telah dijadikan admin di Channel dan Grup Diskusi.</small>
-                        </div>
-                        <p class="text-muted mt-3">
-                            <i class="fas fa-info-circle"></i> Untuk mendapatkan ID Channel/Grup, Anda dapat menggunakan bot seperti <a href="https://t.me/userinfobot" target="_blank">@userinfobot</a>. Forward pesan dari channel/grup Anda ke bot tersebut untuk melihat ID-nya.
-                        </p>
-                    </div>
-                    <div class="card-footer">
-                        <button type="submit" class="btn btn-primary">Simpan Konfigurasi</button>
-                    </div>
-                    </form>
+        <!-- Add New Channel Form -->
+        <div class="col-12">
+            <div class="card card-primary">
+                <div class="card-header">
+                    <h3 class="card-title">Daftarkan Channel Jualan Baru</h3>
                 </div>
+                <form action="/member/channels/register" method="POST">
+                <div class="card-body">
+                    <?php if (isset($_SESSION['flash_error'])) : ?>
+                        <div class="alert alert-danger"><?= htmlspecialchars($_SESSION['flash_error']) ?></div>
+                        <?php unset($_SESSION['flash_error']); ?>
+                    <?php endif; ?>
+                    <?php if (isset($_SESSION['flash_message'])) : ?>
+                        <div class="alert alert-success"><?= htmlspecialchars($_SESSION['flash_message']) ?></div>
+                        <?php unset($_SESSION['flash_message']); ?>
+                    <?php endif; ?>
+
+                    <div class="form-group">
+                        <label for="channel_id">ID Channel Publik</label>
+                        <input type="text" class="form-control" id="channel_id" name="channel_id" placeholder="-1001234567890" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="group_id">ID Grup Diskusi</label>
+                        <input type="text" class="form-control" id="group_id" name="group_id" placeholder="-1009876543210" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="managing_bot_id">Pilih Bot Pengelola</label>
+                        <select class="form-control" id="managing_bot_id" name="managing_bot_id" required>
+                            <option value="">-- Pilih Bot --</option>
+                            <?php foreach ($data['sell_bots'] as $bot) : ?>
+                                <option value="<?= $bot['id'] ?>">
+                                    @<?= htmlspecialchars($bot['username']) ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                        <small class="form-text text-muted">Pastikan bot yang Anda pilih telah dijadikan admin di Channel dan Grup Diskusi.</small>
+                    </div>
+                    <p class="text-muted mt-3">
+                        <i class="fas fa-info-circle"></i> Untuk mendapatkan ID Channel/Grup, Anda dapat menggunakan bot seperti <a href="https://t.me/userinfobot" target="_blank">@userinfobot</a>. Forward pesan dari channel/grup Anda ke bot tersebut untuk melihat ID-nya.
+                    </p>
+                </div>
+                <div class="card-footer">
+                    <button type="submit" class="btn btn-primary">Simpan Konfigurasi</button>
+                </div>
+                </form>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This commit introduces a major feature enhancement allowing sellers to register and manage multiple sales channels, and also fixes the moderation flow for the `/sell` feature.

Key changes:

1.  **Multi-Channel Support**:
    -   Sellers can now register more than one sales channel via the bot or the web panel.
    -   The Member Panel at `/member/channels` has been redesigned to list all registered channels and includes a feature to delete them.
    -   The "Post to Channel" logic now presents the user with a channel selection menu if they have multiple channels registered.
    -   The database repository and relevant controllers (`ContentController`, `MessageHandler`) have been updated to handle arrays of channels instead of a single entity.

2.  **Sell Feature Moderation Fix**:
    -   The `/sell` command now bypasses manual moderation entirely. New packages are created with an `available` status by default.
    -   The channel registration logic now correctly sets `moderation_channel_id` to `NULL` for `sell` feature channels.
    -   A database migration is included to clean up existing data and ensure `moderation_channel_id` is null for all historical `sell` channels.