### PR TITLE
Feat: Overhaul sales channel management and moderation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.2.9] - 2025-09-05
+
+### Peningkatan
+- **Wizard Pendaftaran Channel**: Formulir pendaftaran channel di panel member telah diubah menjadi format wizard multi-langkah yang lebih interaktif dan menarik, meningkatkan pengalaman pengguna saat menambahkan channel baru.
+
 ## [5.2.8] - 2025-09-04
 
 ### Diubah

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.2.10] - 2025-09-05
+
+### Fitur
+- **Perintah /about**: Menambahkan perintah baru `/about` yang menampilkan informasi tentang pengembang bot dan menyediakan link kontak untuk kerja sama.
+
 ## [5.2.9] - 2025-09-05
 
 ### Peningkatan

--- a/core/handlers/MessageHandler.php
+++ b/core/handlers/MessageHandler.php
@@ -95,6 +95,9 @@ class MessageHandler implements HandlerInterface
             case '/help':
                 $this->handleHelpCommand($app, $message);
                 break;
+            case '/about':
+                $this->handleAboutCommand($app, $message);
+                break;
             case '/dev_addsaldo':
             case '/feature':
                 $this->handleAdminCommands($app, $message, $command, $parts);
@@ -227,6 +230,7 @@ class MessageHandler implements HandlerInterface
                 $help_text .= "➡️ `/me`\nLihat profil dan ringkasan penjualan.\n";
                 $help_text .= "➡️ `/balance`\nCek saldo Anda.\n";
                 $help_text .= "➡️ `/login`\nMasuk ke panel member web.\n";
+                $help_text .= "➡️ `/about`\nTentang bot ini.\n";
                 break;
 
             case 'rate':
@@ -235,6 +239,7 @@ class MessageHandler implements HandlerInterface
                 $help_text .= "*--- PERINTAH UMUM ---*\n";
                 $help_text .= "➡️ `/me`\nLihat profil Anda.\n";
                 $help_text .= "➡️ `/login`\nMasuk ke panel member web.\n";
+                $help_text .= "➡️ `/about`\nTentang bot ini.\n";
                 break;
 
             case 'tanya':
@@ -243,6 +248,7 @@ class MessageHandler implements HandlerInterface
                 $help_text .= "*--- PERINTAH UMUM ---*\n";
                 $help_text .= "➡️ `/me`\nLihat profil Anda.\n";
                 $help_text .= "➡️ `/login`\nMasuk ke panel member web.\n";
+                $help_text .= "➡️ `/about`\nTentang bot ini.\n";
                 break;
 
             default: // General or null feature
@@ -250,6 +256,7 @@ class MessageHandler implements HandlerInterface
                 $help_text .= "➡️ `/me`\nLihat profil Anda.\n";
                 $help_text .= "➡️ `/balance`\nCek saldo Anda.\n";
                 $help_text .= "➡️ `/login`\nMasuk ke panel member web.\n";
+                $help_text .= "➡️ `/about`\nTentang bot ini.\n";
                 break;
         }
 
@@ -260,6 +267,22 @@ class MessageHandler implements HandlerInterface
         }
 
         $app->telegram_api->sendLongMessage($app->chat_id, $help_text, 'Markdown');
+    }
+
+    /**
+     * Handle the /about command.
+     *
+     * @param App $app
+     * @param array $message
+     * @return void
+     */
+    private function handleAboutCommand(App $app, array $message): void
+    {
+        $about_text = "🤖 *Tentang Bot Ini*\n\n" .
+                      "Bot ini dikembangkan oleh *Zidin Mitra Abadi*.\n\n" .
+                      "Untuk pertanyaan atau peluang kerja sama, silakan hubungi kami melalui [link ini](https://t.me/your_contact_link_here)."; // Placeholder link
+
+        $app->telegram_api->sendMessage($app->chat_id, $about_text, 'Markdown');
     }
 
     /**

--- a/src/Views/member/content/channels.php
+++ b/src/Views/member/content/channels.php
@@ -62,52 +62,139 @@
             </div>
         </div>
 
-        <!-- Add New Channel Form -->
+        <!-- Add New Channel Form Wizard -->
         <div class="col-12">
             <div class="card card-primary">
                 <div class="card-header">
                     <h3 class="card-title">Daftarkan Channel Jualan Baru</h3>
                 </div>
-                <form action="/member/channels/register" method="POST">
-                <div class="card-body">
-                    <?php if (isset($_SESSION['flash_error'])) : ?>
-                        <div class="alert alert-danger"><?= htmlspecialchars($_SESSION['flash_error']) ?></div>
-                        <?php unset($_SESSION['flash_error']); ?>
-                    <?php endif; ?>
-                    <?php if (isset($_SESSION['flash_message'])) : ?>
-                        <div class="alert alert-success"><?= htmlspecialchars($_SESSION['flash_message']) ?></div>
-                        <?php unset($_SESSION['flash_message']); ?>
-                    <?php endif; ?>
+                <form id="channelWizardForm" action="/member/channels/register" method="POST">
+                    <div class="card-body">
+                        <?php if (isset($_SESSION['flash_error'])) : ?>
+                            <div class="alert alert-danger"><?= htmlspecialchars($_SESSION['flash_error']) ?></div>
+                            <?php unset($_SESSION['flash_error']); ?>
+                        <?php endif; ?>
+                        <?php if (isset($_SESSION['flash_message'])) : ?>
+                            <div class="alert alert-success"><?= htmlspecialchars($_SESSION['flash_message']) ?></div>
+                            <?php unset($_SESSION['flash_message']); ?>
+                        <?php endif; ?>
 
-                    <div class="form-group">
-                        <label for="channel_id">ID Channel Publik</label>
-                        <input type="text" class="form-control" id="channel_id" name="channel_id" placeholder="-1001234567890" required>
+                        <!-- Wizard Steps -->
+                        <div class="wizard-step" id="step1">
+                            <h4>Langkah 1: Masukkan ID Channel Publik</h4>
+                            <p>Masukkan ID numerik dari channel publik tempat Anda akan menampilkan jualan. Pastikan channel bersifat publik.</p>
+                            <div class="form-group">
+                                <label for="channel_id">ID Channel Publik</label>
+                                <input type="text" class="form-control" id="channel_id" name="channel_id" placeholder="-1001234567890" required>
+                            </div>
+                        </div>
+
+                        <div class="wizard-step" id="step2" style="display: none;">
+                            <h4>Langkah 2: Masukkan ID Grup Diskusi</h4>
+                            <p>Masukkan ID numerik dari grup yang terhubung dengan channel publik Anda sebagai grup diskusi.</p>
+                            <div class="form-group">
+                                <label for="group_id">ID Grup Diskusi</label>
+                                <input type="text" class="form-control" id="group_id" name="group_id" placeholder="-1009876543210" required>
+                            </div>
+                        </div>
+
+                        <div class="wizard-step" id="step3" style="display: none;">
+                            <h4>Langkah 3: Pilih Bot Pengelola</h4>
+                            <p>Pilih bot yang akan Anda gunakan untuk mengelola channel ini. Pastikan bot yang Anda pilih telah dijadikan admin di Channel dan Grup Diskusi.</p>
+                            <div class="form-group">
+                                <label for="managing_bot_id">Pilih Bot Pengelola</label>
+                                <select class="form-control" id="managing_bot_id" name="managing_bot_id" required>
+                                    <option value="">-- Pilih Bot --</option>
+                                    <?php foreach ($data['sell_bots'] as $bot) : ?>
+                                        <option value="<?= $bot['id'] ?>">
+                                            @<?= htmlspecialchars($bot['username']) ?>
+                                        </option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                             <p class="text-muted mt-3">
+                                <i class="fas fa-info-circle"></i> Untuk mendapatkan ID Channel/Grup, Anda dapat menggunakan bot seperti <a href="https://t.me/userinfobot" target="_blank">@userinfobot</a>. Forward pesan dari channel/grup Anda ke bot tersebut untuk melihat ID-nya.
+                            </p>
+                        </div>
+
+                        <div class="wizard-step" id="step4" style="display: none;">
+                            <h4>Langkah 4: Konfirmasi</h4>
+                            <p>Silakan periksa kembali semua informasi yang telah Anda masukkan. Jika sudah benar, klik "Simpan Konfigurasi" untuk menyelesaikan pendaftaran.</p>
+                            <ul class="list-group list-group-flush">
+                                <li class="list-group-item"><b>ID Channel Publik:</b> <span id="confirm_channel_id"></span></li>
+                                <li class="list-group-item"><b>ID Grup Diskusi:</b> <span id="confirm_group_id"></span></li>
+                                <li class="list-group-item"><b>Bot Pengelola:</b> <span id="confirm_bot"></span></li>
+                            </ul>
+                        </div>
                     </div>
-                    <div class="form-group">
-                        <label for="group_id">ID Grup Diskusi</label>
-                        <input type="text" class="form-control" id="group_id" name="group_id" placeholder="-1009876543210" required>
+                    <div class="card-footer d-flex justify-content-between">
+                        <button type="button" class="btn btn-secondary" id="prevBtn" style="display: none;">Sebelumnya</button>
+                        <button type="button" class="btn btn-primary" id="nextBtn">Berikutnya</button>
+                        <button type="submit" class="btn btn-success" id="submitBtn" style="display: none;">Simpan Konfigurasi</button>
                     </div>
-                    <div class="form-group">
-                        <label for="managing_bot_id">Pilih Bot Pengelola</label>
-                        <select class="form-control" id="managing_bot_id" name="managing_bot_id" required>
-                            <option value="">-- Pilih Bot --</option>
-                            <?php foreach ($data['sell_bots'] as $bot) : ?>
-                                <option value="<?= $bot['id'] ?>">
-                                    @<?= htmlspecialchars($bot['username']) ?>
-                                </option>
-                            <?php endforeach; ?>
-                        </select>
-                        <small class="form-text text-muted">Pastikan bot yang Anda pilih telah dijadikan admin di Channel dan Grup Diskusi.</small>
-                    </div>
-                    <p class="text-muted mt-3">
-                        <i class="fas fa-info-circle"></i> Untuk mendapatkan ID Channel/Grup, Anda dapat menggunakan bot seperti <a href="https://t.me/userinfobot" target="_blank">@userinfobot</a>. Forward pesan dari channel/grup Anda ke bot tersebut untuk melihat ID-nya.
-                    </p>
-                </div>
-                <div class="card-footer">
-                    <button type="submit" class="btn btn-primary">Simpan Konfigurasi</button>
-                </div>
                 </form>
             </div>
         </div>
     </div>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    let currentStep = 1;
+    const steps = document.querySelectorAll('.wizard-step');
+    const prevBtn = document.getElementById('prevBtn');
+    const nextBtn = document.getElementById('nextBtn');
+    const submitBtn = document.getElementById('submitBtn');
+
+    function showStep(stepNumber) {
+        steps.forEach((step, index) => {
+            step.style.display = (index + 1 === stepNumber) ? 'block' : 'none';
+        });
+
+        prevBtn.style.display = (stepNumber > 1) ? 'inline-block' : 'none';
+        nextBtn.style.display = (stepNumber === steps.length) ? 'none' : 'inline-block';
+        submitBtn.style.display = (stepNumber === steps.length) ? 'inline-block' : 'none';
+    }
+
+    function validateStep(stepNumber) {
+        const currentStepDiv = document.getElementById('step' + stepNumber);
+        const inputs = currentStepDiv.querySelectorAll('input[required], select[required]');
+        for (const input of inputs) {
+            if (!input.value) {
+                alert('Harap isi semua field yang wajib diisi.');
+                input.focus();
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function updateConfirmationDetails() {
+        document.getElementById('confirm_channel_id').textContent = document.getElementById('channel_id').value;
+        document.getElementById('confirm_group_id').textContent = document.getElementById('group_id').value;
+        const botSelect = document.getElementById('managing_bot_id');
+        document.getElementById('confirm_bot').textContent = botSelect.options[botSelect.selectedIndex].text;
+    }
+
+    nextBtn.addEventListener('click', function() {
+        if (validateStep(currentStep)) {
+            if (currentStep < steps.length) {
+                currentStep++;
+                if (currentStep === steps.length) {
+                    updateConfirmationDetails();
+                }
+                showStep(currentStep);
+            }
+        }
+    });
+
+    prevBtn.addEventListener('click', function() {
+        if (currentStep > 1) {
+            currentStep--;
+            showStep(currentStep);
+        }
+    });
+
+    showStep(currentStep);
+});
+</script>


### PR DESCRIPTION
This commit introduces several major improvements and fixes to the sales channel functionality, addressing a series of user requests.

Key changes:

1.  **Multi-Channel Support**:
    -   Sellers can now register, manage, and delete multiple sales channels via the member panel.
    -   The backend logic (Repository, Controllers, Handlers) has been updated to support multiple channels per user.
    -   When posting content, sellers with multiple channels are now prompted to select a destination channel.

2.  **Sell Feature Moderation Fix**:
    -   The `/sell` command now bypasses manual moderation entirely. New packages are created with an `available` status by default.
    -   The channel registration logic now correctly sets `moderation_channel_id` to `NULL` for `sell` feature channels.
    -   A database migration is included to clean up existing data.

3.  **UI/UX Improvements**:
    -   The `/register_channel` bot command has been removed to centralize channel management on the more user-friendly web interface.
    -   The member panel now displays the actual names of the public channel and discussion group, not just their IDs.
    -   The channel registration form has been converted into a multi-step wizard to improve user experience.
    -   A data migration script is included to back-fill names for existing channels.