### PR TITLE
Refactor: Centralize bot feature list in controller

### DIFF
--- a/src/Controllers/Admin/BotController.php
+++ b/src/Controllers/Admin/BotController.php
@@ -28,6 +28,15 @@ use TGBot\TelegramAPI;
 class BotController extends BaseController
 {
     /**
+     * @var string[]
+     */
+    private $available_features = [
+        'sell' => 'Jual (/sell)',
+        'rate' => 'Rating (/rate)',
+        'tanya' => 'Tanya (/tanya)',
+    ];
+
+    /**
      * Menampilkan halaman manajemen bot.
      *
      * @purpose Menampilkan halaman utama "Kelola Bot" yang berisi daftar semua bot
@@ -181,7 +190,8 @@ class BotController extends BaseController
                 'page_title' => 'Edit Bot: ' . htmlspecialchars($bot['first_name']),
                 'bot' => $bot,
                 'settings' => $settings,
-                'status_message' => $status_message
+                'status_message' => $status_message,
+                'available_features' => $this->available_features
             ], 'admin_layout');
         } catch (Exception $e) {
             \app_log('Error in BotController/edit: ' . $e->getMessage(), 'error');
@@ -232,8 +242,7 @@ class BotController extends BaseController
             }
 
             // Handle assigned_feature
-            $valid_features = ['sell', 'rate', 'tanya'];
-            if (in_array($assigned_feature, $valid_features)) {
+            if (array_key_exists($assigned_feature, $this->available_features)) {
                 $stmt_feature = $pdo->prepare("UPDATE bots SET assigned_feature = ? WHERE id = ?");
                 $stmt_feature->execute([$assigned_feature, $bot_id]);
             } else {

--- a/src/Views/admin/bots/edit.php
+++ b/src/Views/admin/bots/edit.php
@@ -75,11 +75,14 @@
         <div class="setting-item" style="margin-bottom: 10px;">
             <label for="assigned_feature">Fitur yang Ditugaskan:</label>
             <select name="assigned_feature" id="assigned_feature" style="padding: 5px; border-radius: 4px; border: 1px solid #ccc;">
-                <?php $feature = $data['bot']['assigned_feature'] ?? null; ?>
+                <?php
+                    $feature = $data['bot']['assigned_feature'] ?? null;
+                    $available_features = $data['available_features'] ?? [];
+                ?>
                 <option value="" <?= empty($feature) ? 'selected' : '' ?>>-- Tidak ada --</option>
-                <option value="sell" <?= ($feature === 'sell') ? 'selected' : '' ?>>Jual (/sell)</option>
-                <option value="rate" <?= ($feature === 'rate') ? 'selected' : '' ?>>Rating (/rate)</option>
-                <option value="tanya" <?= ($feature === 'tanya') ? 'selected' : '' ?>>Tanya (/tanya)</option>
+                <?php foreach ($available_features as $value => $label): ?>
+                <option value="<?= $value ?>" <?= ($feature === $value) ? 'selected' : '' ?>><?= htmlspecialchars($label) ?></option>
+                <?php endforeach; ?>
             </select>
         </div>
 


### PR DESCRIPTION
The list of available bot features (`sell`, `rate`, `tanya`) was hardcoded in both the `BotController` for validation and in the `edit.php` view for the dropdown menu. This violated the DRY principle and made adding new features difficult.

This commit centralizes the feature list into a single private property within the `BotController`. The controller now passes this list to the view, which dynamically generates the dropdown options. The validation logic in the controller also uses this centralized list.

This change improves maintainability by ensuring that features only need to be defined in one place.