### PR TITLE
Fix: Prevent webhook retry loop on handled exceptions

### DIFF
--- a/core/UpdateDispatcher.php
+++ b/core/UpdateDispatcher.php
@@ -156,8 +156,10 @@ class UpdateDispatcher
             if ($this->pdo->inTransaction()) {
                 $this->pdo->rollBack();
             }
-            // Lemparkan kembali agar bisa ditangkap oleh blok catch di webhook.php
-            throw $e;
+            // Log the error, but don't re-throw it. This prevents the webhook from failing
+            // and causing Telegram to send the same update repeatedly.
+            // The specific handler (e.g., BuyCallback) is responsible for notifying the user.
+            app_log("Dispatcher caught a throwable: " . $e->getMessage() . " in " . $e->getFile() . " on line " . $e->getLine(), 'error');
         }
     }
 


### PR DESCRIPTION
This commit resolves an issue where the bot would send multiple duplicate error messages to the user.

The problem was caused by business logic exceptions (e.g., for insufficient balance) being re-thrown all the way up to the top-level script. This caused the script to terminate with a 500 server error. In response, Telegram's servers would assume the webhook delivery had failed and would attempt to resend the same update, creating a loop.

The fix modifies the main `catch` block in `UpdateDispatcher.php`. Instead of re-throwing caught exceptions, it now logs the error and allows the script to terminate gracefully. This ensures a `200 OK` status is returned to Telegram, preventing the retry. User-facing error messages are still sent by the specific handlers (like `BuyCallback`) before the exception is initially thrown.