### PR TITLE
Fix: Ensure admin session is active for balance adjustments

### DIFF
--- a/src/Controllers/Admin/BalanceController.php
+++ b/src/Controllers/Admin/BalanceController.php
@@ -109,6 +109,10 @@ class BalanceController extends BaseController
      */
     public function adjust(): void
     {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+
         if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_POST['action'])) {
             header('Location: /xoradmin/balance');
             exit();


### PR DESCRIPTION
Resolves an "Invalid or expired admin session" error that occurred when an admin tried to add or subtract balance from a user in the xoradmin panel.

The root cause was that the session was not being started on the specific POST request path handled by the `BalanceController::adjust()` method. This resulted in an empty `$_SESSION` array, causing the admin authentication check to fail.

This commit fixes the issue by adding a check at the beginning of the `adjust()` method to ensure `session_start()` is called if no session is currently active. This makes the session data available and allows the admin action to be properly authenticated and processed.