### PR TITLE
Memperbaiki Tautan untuk Melihat Log File

### DIFF
--- a/routes.php
+++ b/routes.php
@@ -45,8 +45,8 @@ $router->get('xoradmin/telegram_logs', 'Admin/LogController@telegram');
 $router->post('xoradmin/telegram_logs/delete', 'Admin/LogController@deleteTelegramLog');
 $router->post('xoradmin/telegram_logs/clear_all', 'Admin/LogController@clearAllTelegramLogs');
 $router->get('xoradmin/file_logs', 'Admin/LogController@viewFileLog');
-$router->get('xoradmin/file_logs/view/{logFileName?}', 'Admin/LogController@viewFileLog'); // New route for viewing file logs
-$router->post('xoradmin/file_logs/clear/{logFileName}', 'Admin/LogController@clearFileLog'); // New route for clearing file logs
+$router->get('xoradmin/file_logs/view/{logFileName?}', 'Admin/LogController@viewFileLog');
+$router->post('xoradmin/file_logs/clear/{logFileName}', 'Admin/LogController@clearFileLog');
 
 // API routes for Admin
 $router->post('api/xoradmin/user/roles', 'Admin/UserController@updateRoles');

--- a/src/Views/admin/logs/file_log.php
+++ b/src/Views/admin/logs/file_log.php
@@ -125,7 +125,7 @@ $current_log_file = $data['log_file_name'] ?? null;
             <ul>
                 <?php foreach ($data['log_files'] as $logFile): ?>
                     <li>
-                        <a href="/xoradmin/file_logs/<?= htmlspecialchars($logFile) ?>" 
+                        <a href="/xoradmin/file_logs/view/<?= htmlspecialchars($logFile) ?>"
                            class="<?= ($logFile === $current_log_file) ? 'active' : '' ?>"
                            title="<?= htmlspecialchars($logFile) ?>">
                             <?= htmlspecialchars($logFile) ?>


### PR DESCRIPTION
Memperbaiki tautan di halaman daftar log agar mengarah ke rute yang benar (/xoradmin/file_logs/view/{namafile}) untuk melihat isi file log.

Sebelumnya, tautan salah mengarah ke /xoradmin/file_logs/{namafile} yang tidak memiliki rute yang sesuai.