### PR TITLE
Mengubah URL untuk Melihat Log File Agar Tanpa Ekstensi .log

### DIFF
--- a/src/Controllers/Admin/LogController.php
+++ b/src/Controllers/Admin/LogController.php
@@ -351,12 +351,15 @@ class LogController extends BaseController
 
             // --- If a log file name IS selected ---
 
+            // Append the .log extension to the filename from the URL
+            $fullLogFileName = $logFileName . '.log';
+
             // Validate the file name to prevent directory traversal
-            if (!in_array($logFileName, $logFiles)) {
-                throw new Exception("File log tidak valid atau tidak ditemukan.");
+            if (!in_array($fullLogFileName, $logFiles)) {
+                throw new Exception("File log tidak valid atau tidak ditemukan: " . htmlspecialchars($fullLogFileName));
             }
 
-            $logFilePath = realpath($baseLogPath . $logFileName);
+            $logFilePath = realpath($baseLogPath . $fullLogFileName);
 
             // Read the last N lines of the file for memory efficiency
             $linesToTail = 1000;
@@ -379,9 +382,9 @@ class LogController extends BaseController
             $paginatedLines = array_slice($logContentArray, $offset, $linesPerPage);
 
             $this->view('admin/logs/file_log', [
-                'page_title'      => 'File Log: ' . htmlspecialchars($logFileName),
+                'page_title'      => 'File Log: ' . htmlspecialchars($fullLogFileName),
                 'log_files'       => $logFiles, // Always pass the file list
-                'log_file_name'   => $logFileName,
+                'log_file_name'   => $fullLogFileName,
                 'raw_log_content' => implode("\n", $paginatedLines),
                 'total_pages'     => $totalPages,
                 'current_page'    => $currentPage,

--- a/src/Views/admin/logs/file_log.php
+++ b/src/Views/admin/logs/file_log.php
@@ -125,7 +125,7 @@ $current_log_file = $data['log_file_name'] ?? null;
             <ul>
                 <?php foreach ($data['log_files'] as $logFile): ?>
                     <li>
-                        <a href="<?= BASE_URL ?>xoradmin/file_logs/view/<?= htmlspecialchars($logFile) ?>"
+                        <a href="<?= BASE_URL ?>xoradmin/file_logs/view/<?= htmlspecialchars(pathinfo($logFile, PATHINFO_FILENAME)) ?>"
                            class="<?= ($logFile === $current_log_file) ? 'active' : '' ?>"
                            title="<?= htmlspecialchars($logFile) ?>">
                             <?= htmlspecialchars($logFile) ?>
@@ -170,8 +170,11 @@ $current_log_file = $data['log_file_name'] ?? null;
                         </form>
 
                         <nav class="inline-flex rounded-md shadow">
-                            <?php for ($i = 1; $i <= $data['total_pages']; $i++): ?>
-                                <a href="<?= BASE_URL ?>xoradmin/file_logs/view/<?= base64_encode($current_log_file) ?>?page=<?= $i ?>&lines=<?= $data['lines_per_page'] ?>"
+                            <?php
+                            $logFileNameWithoutExt = htmlspecialchars(pathinfo($current_log_file, PATHINFO_FILENAME));
+                            for ($i = 1; $i <= $data['total_pages']; $i++):
+                            ?>
+                                <a href="<?= BASE_URL ?>xoradmin/file_logs/view/<?= $logFileNameWithoutExt ?>?page=<?= $i ?>&lines=<?= $data['lines_per_page'] ?>"
                                    class="px-4 py-2 text-sm font-medium <?= ($i == $data['current_page']) ? 'bg-blue-600 text-white' : 'bg-white text-gray-700' ?> border border-gray-300 hover:bg-gray-50">
                                     <?= $i ?>
                                 </a>


### PR DESCRIPTION
Perubahan ini mengimplementasikan permintaan pengguna untuk mengubah struktur URL saat melihat file log. URL sekarang tidak lagi menyertakan ekstensi .log untuk menghindari potensi pemblokiran oleh konfigurasi server.

- `src/Controllers/Admin/LogController.php`: Metode `viewFileLog` sekarang secara otomatis menambahkan ekstensi `.log` ke nama file yang diterima dari URL.
- `src/Views/admin/logs/file_log.php`: Tautan untuk melihat log (termasuk paginasi) sekarang dibuat tanpa ekstensi `.log`.