### PR TITLE
Memperbaiki Routing dan URL untuk Halaman Log

### DIFF
--- a/routes.php
+++ b/routes.php
@@ -45,7 +45,8 @@ $router->get('xoradmin/telegram_logs', 'Admin/LogController@telegram');
 $router->post('xoradmin/telegram_logs/delete', 'Admin/LogController@deleteTelegramLog');
 $router->post('xoradmin/telegram_logs/clear_all', 'Admin/LogController@clearAllTelegramLogs');
 $router->get('xoradmin/file_logs', 'Admin/LogController@viewFileLog');
-$router->get('xoradmin/file_logs/view/{logFileName?}', 'Admin/LogController@viewFileLog');
+$router->get('xoradmin/file_logs/view', 'Admin/LogController@viewFileLog');
+$router->get('xoradmin/file_logs/view/{logFileName}', 'Admin/LogController@viewFileLog');
 $router->post('xoradmin/file_logs/clear/{logFileName}', 'Admin/LogController@clearFileLog');
 
 // API routes for Admin


### PR DESCRIPTION
Perubahan ini memperbaiki serangkaian masalah terkait halaman melihat log, termasuk error 404 dan permintaan untuk URL tanpa ekstensi .log.

- `routes.php`: Menyederhanakan definisi rute untuk melihat log, mengganti parameter opsional dengan dua rute eksplisit untuk menghindari ambiguitas pada router.
- `public/index.php`: Memperbaiki logika parsing URI untuk menangani `BASE_URL` dengan benar, memungkinkan aplikasi berfungsi di subdirektori.
- `src/Controllers/Admin/LogController.php`: Memperbarui controller untuk menangani nama file tanpa ekstensi dari URL dan memuat file yang benar.
- `src/Views/admin/logs/file_log.php`: Memperbarui semua tautan (sidebar, paginasi) untuk menggunakan struktur URL baru tanpa ekstensi `.log` dan `BASE_URL`.